### PR TITLE
fix: identity card exposure during flip

### DIFF
--- a/message_script.json
+++ b/message_script.json
@@ -1,7 +1,7 @@
 {
   "SaveName": "message_script",
-  "EpochTime": 1692875506,
-  "Date": "8/24/2023 7:11:46 PM",
+  "EpochTime": 1693828714,
+  "Date": "9/4/2023 7:58:34 PM",
   "VersionNumber": "v13.2.2",
   "GameMode": "Cards",
   "GameType": "",
@@ -275,7 +275,7 @@
     "TurnColor": "White"
   },
   "DecalPallet": [],
-  "LuaScript": "-- Bundled by luabundle {\"rootModuleName\":\"Global.-1.lua\",\"version\":\"1.6.0\"}\nlocal __bundle_require, __bundle_loaded, __bundle_register, __bundle_modules = (function(superRequire)\n\tlocal loadingPlaceholder = {[{}] = true}\n\n\tlocal register\n\tlocal modules = {}\n\n\tlocal require\n\tlocal loaded = {}\n\n\tregister = function(name, body)\n\t\tif not modules[name] then\n\t\t\tmodules[name] = body\n\t\tend\n\tend\n\n\trequire = function(name)\n\t\tlocal loadedModule = loaded[name]\n\n\t\tif loadedModule then\n\t\t\tif loadedModule == loadingPlaceholder then\n\t\t\t\treturn nil\n\t\t\tend\n\t\telse\n\t\t\tif not modules[name] then\n\t\t\t\tif not superRequire then\n\t\t\t\t\tlocal identifier = type(name) == 'string' and '\\\"' .. name .. '\\\"' or tostring(name)\n\t\t\t\t\terror('Tried to require ' .. identifier .. ', but no such module has been registered')\n\t\t\t\telse\n\t\t\t\t\treturn superRequire(name)\n\t\t\t\tend\n\t\t\tend\n\n\t\t\tloaded[name] = loadingPlaceholder\n\t\t\tloadedModule = modules[name](require, loaded, register, modules)\n\t\t\tloaded[name] = loadedModule\n\t\tend\n\n\t\treturn loadedModule\n\tend\n\n\treturn require, loaded, register, modules\nend)(nil)\n__bundle_register(\"Global.-1.lua\", function(require, _LOADED, __bundle_register, __bundle_modules)\nrequire(\"src.index\")\nend)\n__bundle_register(\"src.index\", function(require, _LOADED, __bundle_register, __bundle_modules)\n-- [Console++](https://tts-vscode.rolandostar.com/extension/console++)\nrequire(\"vscode.console\")\n-- Project Modules: Put all modules here for easy development\nlocal colors = require(\"src.consts.colors\")\nlocal guids = require(\"src.consts.guids\")\nlocal objects = require(\"src.consts.objects\")\nlocal log = require(\"src.utils.log\")\nlocal utils = require(\"src.utils.utils\")\nrequire(\"src.config\")\nlocal setup = require(\"src.setup\")\nlocal start = require(\"src.start\")\nlocal params = require(\"src.consts.params\")\nlocal metadata = require(\"src.consts.metadata\")\nlocal msgCounter = require(\"src.msgCounter\")\nlocal create = require(\"src.create\")\n-- Spawn objects\nlocal seatedPlayerObjectParams = utils.subsetByKeys(params, getSeatedPlayers())\nlocal guidToAttributes = create.objectsFromParams(seatedPlayerObjectParams)\nlocal attributesToGuid = create.attributesToGuid(guidToAttributes)\n-- Event handlers\nlocal zoneHandlers = {\n\t[\"msgDeck\"] = function(zone)\n\t\tmsgCounter.updateMsgFreqDisplay(zone, metadata.actCard, attributesToGuid, guidToAttributes)\n\tend,\n\t-- Add more zone types here\n}\nlocal function handleZoneAction(zone, object)\n\tlocal zoneType = guidToAttributes[zone.getGUID()] and guidToAttributes[zone.getGUID()][\"objectType\"]\n\tif zoneType and zoneHandlers[zoneType] then\n\t\tzoneHandlers[zoneType](zone)\n\tend\nend\n-- Events\nfunction onObjectEnterZone(zone, object)\n\thandleZoneAction(zone, object)\nend\nfunction onObjectLeaveZone(zone, object)\n\thandleZoneAction(zone, object)\nend\n-- project onLoad\nfunction onLoad()\n    log.dev('onLoad')\n    setup.onLoad()\nend\n-- [External Command](https://tts-vscode.rolandostar.com/extension/onExternalCommand)\nfunction onExternalCommand(input)\n    broadcastToAll('command: '..input, colors.red)\n    if input == 'run' then\n        -- do something here for development\n    end\nend\nend)\n__bundle_register(\"src.create\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal create = {}\r\nlocal utils = require(\"src.utils.utils\")\r\n-- Spawn objects and create a mapping from GUID to attributes for game objects\r\n-- @param params: table containing the player and object type information\r\n-- @return guidToAttributes: table mapping each object's GUID to its attributes\r\ncreate.objectsFromParams = function(params)\r\n\tlocal guidToAttributes = {}\r\n\tfor player, objectTypes in pairs(params) do\r\n\t\tfor objectType, objectParams in pairs(objectTypes) do\r\n\t\t\tlocal object = spawnObject(objectParams)\r\n\t\t\tguidToAttributes[object.getGUID()] = utils.append({[\"player\"] = player, [\"objectType\"] = objectType}, objectParams)\r\n\t\tend\r\n\tend\r\n\treturn guidToAttributes\r\nend\r\n-- Create a mapping from attributes to GUID for game objects\r\n-- @param guidToAttributes: table mapping each object's GUID to its attributes\r\n-- @return attributesToGuid: table mapping attributes to GUID\r\ncreate.attributesToGuid = function(guidToAttributes)\r\n\tlocal attributesToGuid = {}\r\n\tfor guid, attributes in pairs(guidToAttributes) do\r\n\t\tlocal player = attributes.player\r\n\t\tlocal objectType = attributes.objectType\r\n\t\tif not attributesToGuid[player] then\r\n\t\t\tattributesToGuid[player] = {}\r\n\t\tend\r\n\t\tattributesToGuid[player][objectType] = guid\r\n\tend\r\n\treturn attributesToGuid\r\nend\r\nreturn create\nend)\n__bundle_register(\"src.utils.utils\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal utils = {}\nutils.contains = function(tbl, e)\n\tfor _, v in pairs(tbl) do\n\t\tif v == e then return true end\n\tend\n\treturn false\nend\nutils.length = function(tbl)\n\tlocal count = 0\n\tfor _ in pairs(tbl) do\n\t\tcount = count + 1\n\tend\n  return count\nend\nutils.randomItem = function(tbl)\n  return tbl[math.random(1, #tbl)]\nend\nutils.append = function(from_tbl, to_tbl)\n\tfor k, v in pairs(from_tbl) do\n\t\tif not to_tbl[k] then\n\t\t\tto_tbl[k] = v\n\t\tend\n\tend\n\treturn to_tbl\nend\nutils.subsetByKeys = function(tbl, keys) \n\tlocal subset = {}\n\tfor _, key in ipairs(keys) do\n\t\tsubset[key] = tbl[key]\n\tend\n\treturn subset\nend\nreturn utils\nend)\n__bundle_register(\"src.msgCounter\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal msgCounter = {}\nlocal utils = require(\"src.utils.utils\")\n-- Get specific attribute values from a metadata table\n-- @param nested_tbl: table containing nested tables\n-- @param child_key: key of a table within another table\n-- @return extract_tbl: table mapping nested_tbl's keys to the attribute value\nlocal function getValuesFromNestedTableByChildKey(nested_tbl, child_key)\n\tlocal extract_tbl = {}\n\tfor parent_key, tbl in pairs(nested_tbl) do\n\t\textract_tbl[parent_key] = nested_tbl[parent_key][child_key]\n\tend\n\treturn extract_tbl\nend\n-- Count the frequency of each value in a table\n-- @param valueTable: table containing values to be counted\n-- @return valueFreq: table mapping each unique value to its frequency\nlocal function countValueFreq(valueTable)\n\tlocal valueFreq = {}\n\tfor key, value in pairs(valueTable) do\n\t\tvalueFreq[value] = (valueFreq[value] or 0) + 1\n\tend\n\treturn valueFreq\nend\n-- Retrieve GUIDs of cards within a target zone\n-- @param targetZone: Zone object to retrieve cards from\n-- @return guids: table containing GUIDs of cards within the zone\nlocal function getCardGUIDsfromZone(targetZone)\n\tlocal guids = {}\n    for _, object in ipairs(targetZone.getObjects()) do\n        if object.getData().Name == \"Card\" then\n            table.insert(guids, object.getGUID())\n        elseif object.getData().Name == \"Deck\" then\n            for _, cardInDeck in ipairs(object.getObjects()) do\n                table.insert(guids, cardInDeck.guid)\n            end\n        end\n    end\n\treturn guids\nend\n-- Count the frequency of messages in a set of cards\n-- @param actCardMeta: table containing metadata for active cards\n-- @param guids: table containing GUIDs of cards to count messages for\n-- @return messageFreq: table mapping each message type to its frequency\nlocal function countMessage(actCardMeta, guids)\n\tlocal subsetActCardMeta = utils.subsetByKeys(actCardMeta, guids)\n\tlocal messageInfo = getValuesFromNestedTableByChildKey(subsetActCardMeta, \"message\")\n\tlocal messageFreq = countValueFreq(messageInfo)\n\treturn messageFreq\nend\n-- Update the message frequency display for a zone\n-- @param zone: Zone object to update the display for\n-- @param metadata: table containing metadata for game objects\n-- @param attributesToGuid: table mapping attributes to object GUIDs\n-- @param guidToAttributes: table mapping object GUIDs to their attributes\nmsgCounter.updateMsgFreqDisplay = function(zone, metadata, attributesToGuid, guidToAttributes)\n\tlocal msgFreq = countMessage(metadata, getCardGUIDsfromZone(zone))\n\tlocal player = guidToAttributes[zone.getGUID()][\"player\"]\n\tgetObjectFromGUID(attributesToGuid[player][\"blackMsgNumDisplay\"]).setValue(tostring(msgFreq.black or 0))\n\tgetObjectFromGUID(attributesToGuid[player][\"blueMsgNumDisplay\"]).setValue(tostring((msgFreq.blue or 0) + (msgFreq.dual or 0)))\n\tgetObjectFromGUID(attributesToGuid[player][\"redMsgNumDisplay\"]).setValue(tostring((msgFreq.red or 0) + (msgFreq.dual or 0)))\nend\nreturn msgCounter\nend)\n__bundle_register(\"src.consts.metadata\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal metadata = {}\r\nmetadata.actCard = {\r\n[\"c5bd16\"] = { message = \"black\" },\r\n[\"9aa160\"] = { message = \"black\" },\r\n[\"acf26c\"] = { message = \"black\" },\r\n[\"cb92ea\"] = { message = \"black\" },\r\n[\"ca44ae\"] = { message = \"black\" },\r\n[\"f3a288\"] = { message = \"black\" },\r\n[\"964486\"] = { message = \"black\" },\r\n[\"004270\"] = { message = \"black\" },\r\n[\"d327cf\"] = { message = \"black\" },\r\n[\"b0a54c\"] = { message = \"black\" },\r\n[\"705167\"] = { message = \"black\" },\r\n[\"afa320\"] = { message = \"black\" },\r\n[\"29e183\"] = { message = \"black\" },\r\n[\"eee983\"] = { message = \"black\" },\r\n[\"ee8727\"] = { message = \"black\" },\r\n[\"1e0537\"] = { message = \"black\" },\r\n[\"88fb48\"] = { message = \"black\" },\r\n[\"8738a1\"] = { message = \"black\" },\r\n[\"1324c7\"] = { message = \"black\" },\r\n[\"42fdb3\"] = { message = \"black\" },\r\n[\"2f9243\"] = { message = \"black\" },\r\n[\"7fff50\"] = { message = \"black\" },\r\n[\"1df492\"] = { message = \"black\" },\r\n[\"8200ce\"] = { message = \"black\" },\r\n[\"11f7cc\"] = { message = \"black\" },\r\n[\"0a5713\"] = { message = \"black\" },\r\n[\"52d575\"] = { message = \"black\" },\r\n[\"2d5396\"] = { message = \"black\" },\r\n[\"54b223\"] = { message = \"black\" },\r\n[\"6161eb\"] = { message = \"black\" },\r\n[\"51e2c5\"] = { message = \"black\" },\r\n[\"35a9c6\"] = { message = \"black\" },\r\n[\"b2717c\"] = { message = \"black\" },\r\n[\"8918bd\"] = { message = \"black\" },\r\n[\"1f6d6b\"] = { message = \"black\" },\r\n[\"1faa74\"] = { message = \"black\" },\r\n[\"64803c\"] = { message = \"black\" },\r\n[\"d4ebfc\"] = { message = \"black\" },\r\n[\"7f4d5f\"] = { message = \"black\" },\r\n[\"d883c6\"] = { message = \"black\" },\r\n[\"18ca1c\"] = { message = \"black\" },\r\n[\"5650fc\"] = { message = \"black\" },\r\n[\"d96c0d\"] = { message = \"red\" },\r\n[\"b2fe77\"] = { message = \"red\" },\r\n[\"d82ddc\"] = { message = \"red\" },\r\n[\"93096a\"] = { message = \"red\" },\r\n[\"672e50\"] = { message = \"red\" },\r\n[\"1fdd73\"] = { message = \"red\" },\r\n[\"2fa342\"] = { message = \"red\" },\r\n[\"bcede5\"] = { message = \"red\" },\r\n[\"bb0cdb\"] = { message = \"red\" },\r\n[\"6f2467\"] = { message = \"red\" },\r\n[\"b690e4\"] = { message = \"red\" },\r\n[\"3b33df\"] = { message = \"red\" },\r\n[\"d1f8bd\"] = { message = \"red\" },\r\n[\"24c7c1\"] = { message = \"red\" },\r\n[\"bdcaf5\"] = { message = \"red\" },\r\n[\"d690f3\"] = { message = \"red\" },\r\n[\"02909f\"] = { message = \"red\" },\r\n[\"873733\"] = { message = \"red\" },\r\n[\"91612f\"] = { message = \"red\" },\r\n[\"5cf9bc\"] = { message = \"red\" },\r\n[\"cc5d8c\"] = { message = \"red\" },\r\n[\"74bd8c\"] = { message = \"blue\" },\r\n[\"b18cd7\"] = { message = \"blue\" },\r\n[\"71fc0b\"] = { message = \"blue\" },\r\n[\"b76da5\"] = { message = \"blue\" },\r\n[\"a6982b\"] = { message = \"blue\" },\r\n[\"73506c\"] = { message = \"blue\" },\r\n[\"5de7c2\"] = { message = \"blue\" },\r\n[\"30014c\"] = { message = \"blue\" },\r\n[\"f247c1\"] = { message = \"blue\" },\r\n[\"959f5a\"] = { message = \"blue\" },\r\n[\"5ab142\"] = { message = \"blue\" },\r\n[\"1d62df\"] = { message = \"blue\" },\r\n[\"55ac2b\"] = { message = \"blue\" },\r\n[\"70abb1\"] = { message = \"blue\" },\r\n[\"341b07\"] = { message = \"blue\" },\r\n[\"4114b8\"] = { message = \"blue\" },\r\n[\"4beb3f\"] = { message = \"blue\" },\r\n[\"3d7eed\"] = { message = \"blue\" },\r\n[\"c92a44\"] = { message = \"blue\" },\r\n[\"0a1931\"] = { message = \"blue\" },\r\n[\"203fdc\"] = { message = \"blue\" },\r\n[\"fb9608\"] = { message = \"dual\" },\r\n[\"7345ee\"] = { message = \"dual\" },\r\n[\"516bf5\"] = { message = \"dual\" }\r\n}\r\nreturn metadata\r\n\nend)\n__bundle_register(\"src.consts.params\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal params = {}\r\nlocal colors = require(\"src.consts.colors\")\r\nparams[colors.white] = {\r\n\tblackMsgNumDisplay = {type = \"3DText\", position = {-2.85, 1.35, -8.15}, scale = {1, 1, 1}, rotation = {90, 0, 0}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tblueMsgNumDisplay = {type = \"3DText\", position = {-4.15, 1.35, -8.15}, scale = {1, 1, 1}, rotation = {90, 0, 0}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tredMsgNumDisplay = {type = \"3DText\", position = {-5.48, 1.35, -8.15}, scale = {1, 1, 1}, rotation = {90, 0, 0}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end },\r\n\tmsgDeck = {type = \"ScriptingTrigger\", position = {1.31, 3.84, -14.33}, scale = {1, 5.1, 1}}\r\n}\r\nparams[colors.red] = {\r\n\tblackMsgNumDisplay = {type = \"3DText\", position = {-17.84, 1.35, -8.15}, scale = {1, 1, 1}, rotation = {90, 0, 0}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tblueMsgNumDisplay = {type = \"3DText\", position = {-19.17, 1.35, -8.15}, scale = {1, 1, 1}, rotation = {90, 0, 0}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tredMsgNumDisplay = {type = \"3DText\", position = {-20.5, 1.35, -8.15}, scale = {1, 1, 1}, rotation = {90, 0, 0}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tmsgDeck = {type = \"ScriptingTrigger\", position = {-13.71, 3.84, -14.33}, scale = {1, 5.1, 1}}\r\n}\r\nparams[colors.pink] = {\r\n\tblackMsgNumDisplay = {type = \"3DText\", position = {12.17, 1.35, -8.15}, scale = {1, 1, 1}, rotation = {90, 0, 0}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tblueMsgNumDisplay = {type = \"3DText\", position = {10.84, 1.35, -8.15}, scale = {1, 1, 1}, rotation = {90, 0, 0}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tredMsgNumDisplay = {type = \"3DText\", position = {9.51, 1.35, -8.15}, scale = {1, 1, 1}, rotation = {90, 0, 0}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tmsgDeck = {type = \"ScriptingTrigger\", position = {16.35, 3.84, -14.33}, scale = {1, 5.1, 1}}\r\n}\r\nparams[colors.yellow] = {\r\n\tblackMsgNumDisplay = {type = \"3DText\", position = {-13.2, 1.35, 3.13}, scale = {1, 1, 1}, rotation = {90, 0, -90}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tblueMsgNumDisplay = {type = \"3DText\", position = {-13.2, 1.35, 4.46}, scale = {1, 1, 1}, rotation = {90, 0, -90}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tredMsgNumDisplay = {type = \"3DText\", position = {-13.2, 1.35, 5.79}, scale = {1, 1, 1}, rotation = {90, 0, -90}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tmsgDeck = {type = \"ScriptingTrigger\", position = {-19.36, 3.84, -0.95}, scale = {1, 5.1, 1}}\r\n}\r\nparams[colors.green] = {\r\n\tblackMsgNumDisplay = {type = \"3DText\", position = {-12.21, 1.35, 9.23}, scale = {1, 1, 1}, rotation = {90, 0, 180}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tblueMsgNumDisplay = {type = \"3DText\", position = {-10.88, 1.35, 9.23}, scale = {1, 1, 1}, rotation = {90, 0, 180}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tredMsgNumDisplay = {type = \"3DText\", position = {-9.55, 1.35, 9.23}, scale = {1, 1, 1}, rotation = {90, 0, 180}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tmsgDeck = {type = \"ScriptingTrigger\", position = {-16.18, 3.84, 15.34}, scale = {1, 5.1, 1}}\r\n}\r\nparams[colors.blue] = {\r\n\tblackMsgNumDisplay = {type = \"3DText\", position = {17.81, 1.35, 9.23}, scale = {1, 1, 1}, rotation = {90, 0, 180}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tblueMsgNumDisplay = {type = \"3DText\", position = {19.14, 1.35, 9.23}, scale = {1, 1, 1}, rotation = {90, 0, 180}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tredMsgNumDisplay = {type = \"3DText\", position = {20.47, 1.35, 9.23}, scale = {1, 1, 1}, rotation = {90, 0, 180}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tmsgDeck = {type = \"ScriptingTrigger\", position = {13.71, 3.84, 15.34}, scale = {1, 5.1, 1}}\r\n}\r\nparams[colors.purple] = {\r\n\tblackMsgNumDisplay = {type = \"3DText\", position = {13.2, 1.35, -2.34}, scale = {1, 1, 1}, rotation = {90, 0, 90}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tblueMsgNumDisplay = {type = \"3DText\", position = {13.2, 1.35, -3.67}, scale = {1, 1, 1}, rotation = {90, 0, 90}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tredMsgNumDisplay = {type = \"3DText\", position = {13.2, 1.35, -5}, scale = {1, 1, 1}, rotation = {90, 0, 90}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\r\n\tmsgDeck = {type = \"ScriptingTrigger\", position = {19.47, 3.84, 1.81}, scale = {1, 5.1, 1}}\r\n}\r\nreturn params\nend)\n__bundle_register(\"src.consts.colors\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal colors = {}\n-- [TTS default color list](https://api.tabletopsimulator.com/color/#colorlist)\nlocal ttsColors = Color.list\ncolors.white = ttsColors[1]\ncolors.brown = ttsColors[2]\ncolors.red = ttsColors[3]\ncolors.orange = ttsColors[4]\ncolors.yellow = ttsColors[5]\ncolors.green = ttsColors[6]\ncolors.teal = ttsColors[7]\ncolors.blue = ttsColors[8]\ncolors.purple= ttsColors[9]\ncolors.pink = ttsColors[10]\ncolors.grey = ttsColors[11]\ncolors.black = ttsColors[12]\nreturn colors\nend)\n__bundle_register(\"src.start\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal start = {}\nlocal utils = require(\"src.utils.utils\")\nlocal colors = require(\"src.consts.colors\")\nlocal objects = require(\"src.consts.objects\")\nlocal warning_color = colors.yellow\nlocal function extractObjectsWithTag(objects, tag)\n    local objectsWithSameTag = {}\n    for _, object in ipairs(objects) do\n       if utils.contains(object.getTags(), tag) then\n            table.insert(objectsWithSameTag, object)\n       end\n    end\n    return objectsWithSameTag\nend\nlocal function hasObjects(objects)\n    return #objects > 0\nend\nlocal function numberOfHandObjects(player)\n    return #Player[player].getHandObjects(1)\nend\nlocal function areAllHandObjectsEqualToNumber(players, number)\n    for _, player in ipairs(players) do\n        if numberOfHandObjects(player) ~= number then\n            return false\n        end\n    end\n    return true\nend\nstart.createStartButton = function()\n    objects.setupButtonScriptZone().createButton({\n        click_function = 'globalStart',\n        label = \"Start\",\n        position = {0,0.8,0},\n        rotation = {0,180,0},\n        width = 500, height = 500, font_size = 150,\n        fontStyle = \"Bold\"\n    })\nend\nstart.start = function ()\n    local seatedPlayers = getSeatedPlayers()\n    if not areAllHandObjectsEqualToNumber(seatedPlayers, 0) then\n        broadcastToAll(\"[WARNING]: place any unused character cards into the 'REMOVE' deck\", warning_color)\n        return\n    end\n    for _, zone in ipairs(getObjectsWithTag(\"character_zone\")) do\n        local cardsInZone = extractObjectsWithTag(zone.getObjects(), \"scripted\")\n        if not hasObjects(cardsInZone) then\n            broadcastToAll(\"[WARNING]: place the character card you want to use in the designated character zone on your panel\", warning_color)\n            return\n        end\n    end\n    objects.actDeck().deal(2)\n    Turns.turn_color = utils.randomItem(seatedPlayers)\n    objects.setupButtonScriptZone().clearButtons()\nend\nfunction globalStart()\n    start.start()\nend\nreturn start\nend)\n__bundle_register(\"src.consts.objects\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal objects = {}\nlocal guids = require(\"src.consts.guids\")\nlocal function getObjFun(guid)\n    return function() return getObjectFromGUID(guid) end\nend\n-- Get the object by calling a function, like: objects.idDeck()\n-- Add objects by GUID using getObjFun as follows\nobjects.idDeck = getObjFun(guids.idDeck)\nobjects.charDeck = getObjFun(guids.charDeck)\nobjects.setupButtonScriptZone = getObjFun(guids.setupButtonScriptZone)\nobjects.idDeck_zone = getObjFun(guids.idDeck_zone)\nobjects.actDeck = getObjFun(guids.actDeck)\nreturn objects\nend)\n__bundle_register(\"src.consts.guids\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal guids = {}\n-- GUIDs must be added below\nguids.idDeck = \"937c8b\"\nguids.charDeck = \"30c66e\"\nguids.setupButtonScriptZone = \"2816c9\"\nguids.idDeck_zone = \"9a0b41\"\nguids.actDeck = \"4a8259\"\nreturn guids\nend)\n__bundle_register(\"src.setup\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal setup = {}\nlocal utils = require(\"src.utils.utils\")\nlocal log = require(\"src.utils.log\")\nlocal start = require(\"src.start\")\nlocal objects = require(\"src.consts.objects\")\nlocal colors = require(\"src.consts.colors\")\nlocal function getSetUpButtonParameters()\n    return {\n        click_function = 'globalSetUp',\n        function_owner = nil,\n        label = \"Set up\",\n        position = {0,0.8,0},\n        rotation = {0,180,0},\n        width = 500,\n        height = 500,\n        font_size = 150,\n        fontStyle = \"Bold\"\n    }\nend\nfunction setup.onLoad()\n    log.dev('setup.onLoad')\n    objects.setupButtonScriptZone().createButton(getSetUpButtonParameters())\nend\nlocal function moveObjectsWithoutTag(source, target, tag)\n    for _, object in ipairs(source.getObjects()) do\n        if not utils.contains(object.tags, tag) then\n            local takenObject = source.takeObject({guid = object.guid, smooth = true})\n            target.putObject(takenObject)\n        end\n    end\nend\nlocal function whosObject(object)\n    local seatedPlayers = getSeatedPlayers()\n    for _, color in ipairs(seatedPlayers) do\n        if utils.contains(object.getTags(), color) then\n            return color\n        end\n    end\nend\nlocal function distributeCardsToEachZone(deck, zones)\n    deck.shuffle()\n    for _, zone in ipairs(zones) do\n        local card = deck.takeObject()\n        card.setPosition(zone.getPosition())\n        card.setRotation(zone.getRotation())\n        card.addTag(whosObject(zone))\n    end\nend\nlocal function removeUnusedPlayerObjects()\n    -- this function assumes that target objects have corresponding tags (i.e. color name) to their owner\n    local player_colors = {colors.white, colors.red, colors.yellow, colors.green, colors.blue, colors.purple, colors.pink}\n    for _, color in ipairs(player_colors) do\n        if not utils.contains(getSeatedPlayers(), color) then\n            for _, object in ipairs(getObjectsWithTag(color)) do\n                destroyObject(object)\n            end\n        end \n    end\nend\nlocal function dealCards(deck, num)\n    deck.shuffle()\n    deck.deal(num)\nend\nsetup.setUp = function()\n    local numPlayers = utils.length(getSeatedPlayers())\n    if numPlayers < 3 or numPlayers > 7 then\n       broadcastToAll(\"[WARNING]: This game only supports 3 - 7 players\", \"Yellow\") \n       return\n    end\n    removeUnusedPlayerObjects()\n    broadcastToAll(\"[INFO]: Select a character card and put it into your panel\")\n    dealCards(objects.charDeck(), 3)\n    objects.setupButtonScriptZone().clearButtons()\n    local playerTag = \"player_\" .. tostring(numPlayers)\n    moveObjectsWithoutTag(objects.idDeck(), objects.charDeck(), playerTag)\n    distributeCardsToEachZone(objects.idDeck(), getObjectsWithTag(\"identity_zone\"))\n    -- TODO: Currently waiting for other cards to clear to avoid deck misidentification.\n    -- Needs a more robust solution to eliminate dependency on wait time.\n    Wait.time(\n        function ()\n            for _, object in ipairs(objects.idDeck_zone().getObjects()) do\n                objects.charDeck().putObject(object)\n            end\n        end,\n        0.05\n    )\n    start.createStartButton()\nend\nfunction globalSetUp()\n    setup.setUp()\nend\nreturn setup\nend)\n__bundle_register(\"src.utils.log\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal log = {}\nfunction log.dev(message)\n    if dev then\n        print('dev: ', message)\n    end\nend\nreturn log\nend)\n__bundle_register(\"src.config\", function(require, _LOADED, __bundle_register, __bundle_modules)\n-- project configurations\ndev = true\nend)\n__bundle_register(\"vscode.console\", function(require, _LOADED, __bundle_register, __bundle_modules)\nrequire(\"Console/console++\")\r\n\r\n-- function prototype\r\nfunction onExternalCommand(command) end\r\n\r\n-- Overwrite onChat function if you rather be handled by onExternalMessage\r\n-- function onChat(message, player) end\r\n\r\nfunction onExternalMessage(data)\r\n  if data.input ~= nil then onExternalCommand(data.input) end\r\n  if data.command ~= nil then\r\n    local hostPlayer\r\n    local players = getSeatedPlayers()\r\n    for key, value in pairs(players) do\r\n      if Player[value].host then\r\n        hostPlayer = Player[value]\r\n      end\r\n    end\r\n    if data.command ~= '' then\r\n      local command = ''\r\n      local command_function = nil\r\n      local parameters = {hostPlayer}\r\n      local requires_admin = false\r\n      local command_mode = console.in_command_mode[hostPlayer.steam_id]\r\n      if command_mode and console.active then\r\n          command, command_function, parameters, requires_admin = console.get_command(data.command, hostPlayer)\r\n      elseif data.command:sub(1, 1) == console.command_char and console.active then\r\n          if data.command:len() > 1 then\r\n              command, command_function, parameters, requires_admin = console.get_command(data.command:sub(2), hostPlayer)\r\n          else\r\n              command, command_function, parameters, requires_admin = console.get_command(console.command_char, hostPlayer)\r\n          end\r\n      else\r\n          for i, f in ipairs(console.validation_functions) do\r\n              local valid, response = f(data.command)\r\n              if response == nil then response = '' end\r\n              if not valid then\r\n                  printToColor(response, hostPlayer.color, console.invalid_color)\r\n                  return false\r\n              end\r\n          end\r\n          return true\r\n      end\r\n      if console.active then\r\n          if command_function and (hostPlayer.admin or not requires_admin) then\r\n              if command_mode then\r\n                  data.command = console.command_char .. console.command_char .. data.command\r\n              end\r\n              local response, mute = command_function(unpack(parameters))\r\n              if response ~= nil or mute ~= nil then\r\n                  if not mute then\r\n                      printToColor('\\n'..data.command, hostPlayer.color, console.command_color)\r\n                  end\r\n                  if response then\r\n                      printToColor(response, hostPlayer.color, console.output_color)\r\n                  end\r\n              end\r\n              if console.in_command_mode[hostPlayer.steam_id] then console.display_prompt(hostPlayer) end\r\n              return false\r\n          else\r\n              printToColor('\\n'..data.command, hostPlayer.color, console.command_color)\r\n              printToColor(console.error_bb .. \"<command '\" .. command .. \"' not found>[-]\", hostPlayer.color, console.output_color)\r\n              return false\r\n          end\r\n      end\r\n    end\r\n  end\r\nend\r\n\nend)\n__bundle_register(\"Console/console++\", function(require, _LOADED, __bundle_register, __bundle_modules)\nrequire(\"Console/console\")\r\n\r\nif not console.plusplus then\r\n    console.plusplus = true\r\n\r\n    -- Change these values as you wish\r\n    console.seperator         = '/'\r\n    console.wildcard          = '*'\r\n    console.literal           = '`'  -- string parameters will be treated as paths where apt unless prefixed with this\r\n    console.result            = '~'  -- refers to the most recently returned result from a call\r\n    console.command_seperator = ';'  -- used in batch files to seperate commands\r\n    console.indent            = '  '\r\n    console.crop_string_at = 20\r\n    console.builtin_path = 'sys'\r\n    console.table_bb    = '[EEDD88]'\r\n    console.hidden_bb   = '[DDAAAA]'\r\n    console.function_bb = '[AADDAA]'\r\n    console.value_bb    = '[88EE88]'\r\n    console.boolean_bb  = '[CCCCFF]'\r\n    console.object_bb   = '[CCBBCC]'\r\n    console.guid_bb     = '[BBBBBB]'\r\n\r\n    console.autoexec         = ''\r\n    console.autoexec_options = '-s'\r\n\r\n    -- Exposed methods:\r\n\r\n    function console.hide_globals(label)\r\n        -- all globals present when you call this will be hidden under <label> (unless built-in or already hidden)\r\n        local hidden = {}\r\n        for global, _ in pairs(_G) do\r\n            local found = false\r\n            for _, globals in pairs(console.hidden_globals) do\r\n                if globals[global] then\r\n                    found = true\r\n                    break\r\n                end\r\n            end\r\n            if not found then\r\n                table.insert(hidden, global)\r\n            end\r\n        end\r\n        if console.hidden_globals[label] == nil then\r\n            console.hidden_globals[label] = {}\r\n        end\r\n        for _, global in ipairs(hidden) do\r\n            console.hidden_globals[label][global] = true\r\n        end\r\n    end\r\n\r\n    function console.load()\r\n        -- call this function in an onLoad event to enable the autoexec\r\n        console.cd = console.seperator\r\n        for _, player in pairs(getSeatedPlayers()) do\r\n            if Player[player].admin then\r\n                console.commands['exec'].command_function(Player[player], console.seperator..'console'..console.seperator..'autoexec', console.autoexec_options)\r\n                break\r\n            end\r\n        end\r\n    end\r\n\r\n    function console.update()\r\n        -- call this function in an onUpdate event to enable the watch list\r\n        if console.watch_list and not console.watch_list_paused then\r\n            for variable, watch in pairs(console.watch_list) do\r\n                if watch.throttle == 0 or watch.last_check + watch.throttle < os.clock() then\r\n                    watch.last_check = os.clock()\r\n                    local node, id, parent, found\r\n                    if watch.is_guid then\r\n                        node = getObjectFromGUID(variable)\r\n                        found = tostring(node) ~= 'null'\r\n                    else\r\n                        node, id, parent, found = console.node_from_path(variable)\r\n                    end\r\n                    if node ~= nil and found then\r\n                        if type(node) == 'userdata' then\r\n                            if tostring(node) ~= 'null' then\r\n                                local p = function (x) return math.floor(x * 100) * 0.01 end\r\n                                local r = function (x) return math.floor(x + 0.5) end\r\n                                local position = node.getPosition()\r\n                                local rotation = node.getRotation()\r\n                                if p(position.x) ~= p(watch.position.x) or r(rotation.x) ~= r(watch.rotation.x) or\r\n                                   p(position.y) ~= p(watch.position.y) or r(rotation.y) ~= r(watch.rotation.y) or\r\n                                   p(position.z) ~= p(watch.position.z) or r(rotation.z) ~= r(watch.rotation.z) then\r\n                                   watch.position = position\r\n                                   watch.rotation = rotation\r\n                                   node = ' ∡ '..r(rotation.x)..' '..r(rotation.y)..' '..r(rotation.z) ..\r\n                                        console.boolean_bb..'   ⊞  '..p(position.x)..'   '..p(position.y)..'   '..p(position.z)\r\n                                   if watch.is_guid then\r\n                                       variable = console.format_guid(variable)\r\n                                   else\r\n                                       variable = console.object_bb .. variable .. '[-]'\r\n                                   end\r\n                                   printToColor(variable .. console.value_bb .. node .. '[-]', watch.player, console.output_color)\r\n                                end\r\n                            end\r\n                        elseif type(node) == 'function' then\r\n                            local result = node(unpack(watch.parameters))\r\n                            if watch.property and (type(result) == 'table' or type(result) == 'userdata') then\r\n                                result = result[watch.property]\r\n                                if type(result) == 'function' then\r\n                                    result = result()\r\n                                end\r\n                            end\r\n                            if result ~= watch.value then\r\n                                watch.value = result\r\n                                result = tostring(result)\r\n                                if result:len() > console.crop_string_at then result = result:sub(1, console.crop_string_at) .. '...' end\r\n                                if result:len() == 6 and watch.label:lower():find('guid') then result = console.format_guid(result) end\r\n                                printToColor(watch.label .. console.value_bb .. result .. '[-]', watch.player, console.output_color)\r\n                            end\r\n                        else\r\n                            if node ~= watch.value then\r\n                                watch.value = node\r\n                                if type(node) == 'boolean' then\r\n                                    if node then\r\n                                        node = 'true'\r\n                                    else\r\n                                        node = 'false'\r\n                                    end\r\n                                elseif type(node) == 'string' then\r\n                                    if node:len() > console.crop_string_at then node = node:sub(1, console.crop_string_at):gsub('\\n', ' ') .. '...' end\r\n                                end\r\n                                printToColor(variable .. ': ' .. console.value_bb .. node .. '[-]', watch.player, console.output_color)\r\n                            end\r\n                        end\r\n                    end\r\n                end\r\n            end\r\n        end\r\n    end\r\n\r\n    -- simple swear-blocking validation\r\n    console.add_validation_function(\r\n        function (message)\r\n            local message = message:lower()\r\n            for i, bad_word in pairs({'fuck', 'cunt'}) do\r\n                if message:find(bad_word) then\r\n                    return false, \"No swearing!\"\r\n                end\r\n            end\r\n            return true\r\n        end\r\n    )\r\n\r\n    -- End of exposed methods.  You shouldn't need to interact with anything below (under normal circumstances)\r\n\r\n\r\n    -- override default prompt with one which displays current table\r\n    function console.display_prompt(player)\r\n        printToColor(console.cd .. ' ' .. console.command_char..console.command_char, player.color, console.prompt_color)\r\n    end\r\n\r\n\r\n    -- console++ follows\r\n\r\n    console.cd = console.seperator\r\n    console.hidden_globals = {}\r\n    console.hide_globals(console.builtin_path)\r\n\r\n    function console.is_hidden(label)\r\n        for _, globals in pairs(console.hidden_globals) do\r\n            if globals[label] then\r\n                return true\r\n            end\r\n        end\r\n        return false\r\n    end\r\n\r\n    function console.escape_bb(s)\r\n        local s = tostring(s)\r\n        if s == '' then\r\n            return ''\r\n        else\r\n            local r = ''\r\n            for c = 1, s:len() do\r\n                local char = s:sub(c, c)\r\n                if char == '[' then\r\n                    r = r .. '[\\u{200B}'\r\n                elseif char == ']' then\r\n                    r = r .. '\\u{200B}]'\r\n                else\r\n                    r = r .. char\r\n                end\r\n            end\r\n            return r\r\n        end\r\n    end\r\n\r\n    function console.format_guid(guid)\r\n        return console.guid_bb .. '⁅' .. guid .. '⁆[-]'\r\n    end\r\n\r\n    function console.fill_path(path)\r\n        local path = path\r\n        local filter = nil\r\n        if path == nil then\r\n            return console.cd, filter\r\n        end\r\n        local c = path:len()\r\n        if path:sub(c) ~= console.seperator then\r\n            local found = false\r\n            while c > 0 do\r\n                local char = path:sub(c, c)\r\n                if char == console.wildcard then\r\n                    found = true\r\n                elseif char == console.seperator then\r\n                    break\r\n                end\r\n                c = c - 1\r\n            end\r\n            if found then\r\n                filter = '^'\r\n                for i = c + 1, path:len() do\r\n                    local char = path:sub(i, i)\r\n                    if char == console.wildcard then\r\n                        filter = filter .. '.*'\r\n                    else\r\n                        filter = filter .. char\r\n                    end\r\n                end\r\n                filter = filter .. '$'\r\n                path = path:sub(1, c)\r\n            end\r\n        end\r\n        if path:sub(1,1) == console.seperator then\r\n            return path, filter\r\n        else\r\n            return console.cd .. path, filter\r\n        end\r\n    end\r\n\r\n    function console.node_from_path(path)\r\n        local node = _G\r\n        local id = {''}\r\n        local parent = {nil}\r\n        local found = true\r\n        local depth = 0\r\n        local stack = {}\r\n        local hidden = nil\r\n        local ends_with_table = {true}\r\n        if path == 'true' then\r\n            node = true\r\n        elseif path == 'false' then\r\n            node = false\r\n        elseif path ~= console.seperator then\r\n            for i, part in ipairs(console.split(path, console.seperator)) do\r\n                if part == '..' then\r\n                    if depth > 0 then\r\n                        node = table.remove(parent)\r\n                        table.remove(id)\r\n                        table.remove(stack)\r\n                        table.remove(ends_with_table)\r\n                        depth = depth - 1\r\n                    end\r\n                elseif part == '.' then\r\n                    ; -- do nothing, . = where we are\r\n                elseif part == console.result then\r\n                    table.insert(parent, node)\r\n                    table.insert(id, part)\r\n                    table.insert(stack, part)\r\n                    node = console.returned_value\r\n                    table.insert(ends_with_table, type(node) == 'table')\r\n                    depth = depth + 1\r\n                elseif node[part] ~= nil then\r\n                    table.insert(parent, node)\r\n                    table.insert(id, part)\r\n                    table.insert(stack, part)\r\n                    node = node[part]\r\n                    table.insert(ends_with_table, type(node) == 'table')\r\n                    depth = depth + 1\r\n                elseif node == _G and console.hidden_globals[part] then\r\n                    hidden = console.hidden_globals[part]\r\n                else\r\n                    table.insert(id, part)\r\n                    found = false\r\n                    break\r\n                end\r\n            end\r\n        end\r\n        path = ''\r\n        for i, part in ipairs(stack) do\r\n            path = path .. console.seperator .. part\r\n        end\r\n        if table.remove(ends_with_table) then\r\n            path = path .. console.seperator\r\n        end\r\n        return node, table.remove(id), table.remove(parent), found, path, hidden\r\n    end\r\n\r\n\r\n    -- commands\r\n\r\n    console.add_admin_command('cd', '[<table>]',\r\n        'Display current table or change current table',\r\n        function (player, path)\r\n            if path == nil then\r\n                return console.cd\r\n            else\r\n                path = tostring(path)\r\n            end\r\n            local location = console.fill_path(path)\r\n            local node, id, parent, found, location = console.node_from_path(location)\r\n            local text = nil\r\n            if node ~= nil and found and type(node) == 'table' then\r\n                console.cd = location\r\n                if not console.in_command_mode[player.steam_id] then text = console.cd end\r\n            else\r\n                text = console.error_bb .. '<not found>[-]'\r\n            end\r\n            return text, false\r\n        end\r\n    )\r\n    console.add_admin_command('cd..', '', 'Change current table to parent table.', 'cd', {'..'})\r\n\r\n    console.add_admin_command('ls', '[' .. console.option .. '?afotv] [' .. console.option .. 'r[#]] [<table>]',\r\n        'Display variables in current table or specified table',\r\n        function (player, ...)\r\n            local help_details = console.header_bb .. 'Options[-]\\n' ..\r\n                'Show:\\n '..console.option..'f functions\\n '..console.option..'o objects\\n '..\r\n                console.option..'v variables (defaults to on)\\n '..console.option..'t tables (defaults to on)\\n '..\r\n                console.option..'a all\\n\\n' ..console.option..'r[#] recurse [# layers if specified]'\r\n            local path = console.cd\r\n            local display_functions = false\r\n            local display_objects = false\r\n            local display_variables = false\r\n            local display_tables = false\r\n            local display_all = false\r\n            local recursions_left = 0\r\n            for i, arg in ipairs({...}) do\r\n                arg = tostring(arg)\r\n                if arg:len() > 1 and arg:sub(1,1) == console.option then\r\n                    local c = 2\r\n                    while c <= arg:len() do\r\n                        local option = arg:sub(c,c)\r\n                        if option == 'f' then\r\n                            display_functions = not display_functions\r\n                        elseif option == 'o' then\r\n                            display_objects = not display_objects\r\n                        elseif option == 'v' then\r\n                            display_variables = not display_variables\r\n                        elseif option == 't' then\r\n                            display_tables = not display_tables\r\n                        elseif option == 'a' then\r\n                            display_all = not display_all\r\n                        elseif option == 'r' then\r\n                            local n = ''\r\n                            local j = c + 1\r\n                            while j <= arg:len() do\r\n                                local char = arg:sub(j, j)\r\n                                if char:match('%d') then\r\n                                    n = n .. char\r\n                                else\r\n                                    break\r\n                                end\r\n                                j = j + 1\r\n                            end\r\n                            c = j - 1\r\n                            if n == '' then\r\n                                recursions_left = 20\r\n                            else\r\n                                recursions_left = tonumber(n)\r\n                            end\r\n                        elseif option == '?' or option == 'h' then\r\n                            return help_details\r\n                        else\r\n                            return console.error_bb .. \"<option '\" .. console.option .. option .. \"' not recognized>[-]\\n\"\r\n                        end\r\n                        c = c + 1\r\n                    end\r\n                else\r\n                    path = arg\r\n                end\r\n            end\r\n            local default_variables = not (display_tables or display_objects or display_functions or display_variables)\r\n            if display_functions or display_objects or display_variables then\r\n                display_tables = not display_tables\r\n            end\r\n            if display_all then\r\n                display_functions = true\r\n                display_objects = true\r\n                display_variables = true\r\n                display_tables = true\r\n            elseif default_variables then\r\n                display_functions = false\r\n                display_objects = false\r\n                display_variables = true\r\n                display_tables = true\r\n            end\r\n            local location, filter = console.fill_path(path)\r\n            return console.ls(player, location, filter, display_functions, display_objects, display_variables, display_tables, recursions_left)\r\n        end\r\n    )\r\n    console.add_admin_command('dir', nil, nil, 'ls')\r\n    console.add_admin_command(console.result, '', \"Calls 'ls \"..console.option..\"a \"..console.result..\"'\", 'ls', {console.option..'a', console.result})\r\n\r\n    function console.ls(player, path, filter, display_functions, display_objects, display_variables, display_tables, recursions_left, indent)\r\n        local text = ''\r\n        local indent = indent or ''\r\n        local node, id, parent, found, location, hidden = console.node_from_path(path)\r\n        local paths = {}\r\n        if node ~= nil and (found or hidden) then\r\n            if type(node) == 'table' then\r\n                local tables = {}\r\n                local entries = {}\r\n                for k, v in pairs(node) do\r\n                    if (node ~= _G or (not hidden and not console.is_hidden(k)) or (hidden and hidden[k])) and (filter == nil or k:match(filter)) then\r\n                        if type(v) == 'table' then\r\n                            local t = console.table_bb .. k .. '[-]'\r\n                            table.insert(tables, t)\r\n                            paths[t] = path .. console.seperator .. k\r\n                        else\r\n                            if type(v) == 'function' then\r\n                                if display_functions then\r\n                                    table.insert(entries, console.function_bb .. k .. '[-]()')\r\n                                end\r\n                            elseif type(v) == 'userdata' then\r\n                                if display_objects then\r\n                                    local tag = tostring(v)\r\n                                    if tag:find('(LuaGameObjectScript)') and not tag:gsub('(LuaGameObjectScript)',''):find('Script ') then\r\n                                        tag = v.tag .. ' ' .. console.format_guid(v.getGUID())\r\n                                    end\r\n                                    if type(k) == 'number' and math.floor(k) == k then k = string.format('%04d', k) end\r\n                                    table.insert(entries, console.object_bb .. k .. '[-]: '  .. tag)\r\n                                end\r\n                            elseif display_variables then\r\n                                if type(v) == 'boolean' then\r\n                                    if v then\r\n                                        v = 'true'\r\n                                    else\r\n                                        v = 'false'\r\n                                    end\r\n                                    table.insert(entries, k .. ': ' .. console.boolean_bb .. v .. '[-]')\r\n                                else\r\n                                    local is_guid = false\r\n                                    if type(v) == 'string' then\r\n                                        if v:len()> console.crop_string_at then v = v:sub(1, console.crop_string_at):gsub('\\n', ' ') .. '...' end\r\n                                        if type(k) == 'string' and k:lower():find('guid') and v:len() == 6 then\r\n                                            is_guid = true\r\n                                        end\r\n                                    end\r\n                                    if is_guid then\r\n                                        table.insert(entries, k .. ': ' .. console.format_guid(v) .. '[-]')\r\n                                    else\r\n                                        table.insert(entries, k .. ': ' .. console.value_bb .. console.escape_bb(v) .. '[-]')\r\n                                    end\r\n                                end\r\n                            end\r\n                        end\r\n                    end\r\n                end\r\n                local cmp = function (a, b)\r\n                    if not a then\r\n                        return true\r\n                    elseif not b then\r\n                        return false\r\n                    else\r\n                        local la = a:len()\r\n                        local lb = b:len()\r\n                        local c = 1\r\n                        repeat\r\n                            if c > la and c <= lb then\r\n                                return true\r\n                            elseif c > lb and c <= la then\r\n                                return false\r\n                            elseif c > la then\r\n                                return false\r\n                            else\r\n                                local ba = a:sub(c, c):byte()\r\n                                local bb = b:sub(c, c):byte()\r\n                                if ba < bb then\r\n                                    return true\r\n                                elseif bb < ba then\r\n                                    return false\r\n                                end\r\n                            end\r\n                            c = c + 1\r\n                        until false\r\n                    end\r\n                end\r\n                table.sort(tables, cmp)\r\n                table.sort(entries, cmp)\r\n                local cr = ''\r\n                if display_tables then\r\n                    for i, t in ipairs(tables) do\r\n                        text = text .. cr .. indent .. t .. console.seperator\r\n                        if recursions_left ~= 0 then\r\n                            text = text .. '\\n' .. console.ls(player, paths[t], filter,\r\n                                display_functions, display_objects, display_variables, display_tables,\r\n                                recursions_left-1, indent..console.indent)\r\n                        end\r\n                        cr = '\\n'\r\n                    end\r\n                    if node == _G and not hidden then\r\n                        for label, _ in pairs(console.hidden_globals) do\r\n                            if (filter == nil or label:match(filter)) then -- and label ~= console.builtin_path\r\n                                text = text .. cr .. indent .. console.hidden_bb .. label .. console.seperator .. '[-]'\r\n                                cr = '\\n'\r\n                            end\r\n                        end\r\n                    end\r\n                end\r\n                for _, entry in ipairs(entries) do\r\n                    text = text .. cr .. indent .. entry\r\n                    cr = '\\n'\r\n                end\r\n            elseif type(node) == 'userdata' then\r\n                local tag = tostring(node)\r\n                if tag ~= 'null' and tag:find('(LuaGameObjectScript)') and not tag:gsub('(LuaGameObjectScript)',''):find('Script ') then\r\n                    tag = node.tag .. ' ' .. console.format_guid(node.getGUID())\r\n                end\r\n                text = indent .. console.object_bb .. id .. '[-]: ' .. tag\r\n            elseif type(node) == 'function' then\r\n                text = indent .. console.function_bb .. id .. '[-]()'\r\n            elseif type(node) == 'boolean' then\r\n                if node then\r\n                    text = indent .. id .. ': ' .. console.boolean_bb .. 'true[-]'\r\n                else\r\n                    text = indent .. id .. ': ' .. console.boolean_bb .. 'false[-]'\r\n                end\r\n            else\r\n                if type(id) == 'string' and id:lower():find('guid') and type(node) == 'string' and node:len() == 6 then\r\n                    text = indent .. id .. ': ' .. console.format_guid(node) .. '[-]'\r\n                else\r\n                    text = indent .. id .. ': ' .. console.value_bb .. console.escape_bb(node) .. '[-]'\r\n                end\r\n            end\r\n        else\r\n            text = indent .. console.error_bb .. '<not found>[-]'\r\n        end\r\n        return text\r\n    end\r\n\r\n    console.add_admin_command('call', '<function> [<parameter>...]',\r\n        'Call function with parameters and display result.',\r\n        function (player, ...)\r\n            local path = nil\r\n            local parameters = {}\r\n            for i, arg in ipairs({...}) do\r\n                if i == 1 then\r\n                    path = tostring(arg)\r\n                else\r\n                    if type(arg) == 'string' then\r\n                        if arg:len() > 2 and arg:sub(1,1) == console.literal then\r\n                            arg = arg:sub(2)\r\n                        else\r\n                            local node, id, parent, found = console.node_from_path(console.fill_path(arg))\r\n                            if node ~= nil and found then\r\n                                arg = node\r\n                            end\r\n                        end\r\n                    end\r\n                    table.insert(parameters, arg)\r\n                end\r\n            end\r\n            if path == nil then\r\n                return console.error_bb .. '<you must supply a function>[-]'\r\n            end\r\n            local location = console.fill_path(path)\r\n            local node, id, parent, found, location = console.node_from_path(location)\r\n            local text = nil\r\n            if node ~= nil and found and type(node) == 'function' then\r\n                console.returned_value = node(unpack(parameters))\r\n                text = tostring(console.returned_value)\r\n                if console.deferred_assignment then\r\n                    local da = console.deferred_assignment\r\n                    if da.command == 'set' then\r\n                        if da.parent[da.id] ~= nil then\r\n                            if da.force or type(console.returned_value) == type(da.parent[da.id]) then\r\n                                da.parent[da.id] = console.returned_value\r\n                                text = text .. '\\n' .. console.header_bb .. \"<set '\" .. da.id .. \"'>[-]\"\r\n                            else\r\n                                text = text .. '\\n' .. console.error_bb .. \"<cannot set '\" .. da.id .. \"': it is of type '\" .. type(da.parent[da.id]) .. \"'>[-]\"\r\n                            end\r\n                        else\r\n                            text = text .. '\\n' .. console.error_bb .. \"<cannot set '\" .. da.id .. \"': it does not exist>[-]\"\r\n                        end\r\n                    elseif da.command == 'add' then\r\n                        if da.parent[da.id] == nil then\r\n                            da.parent[da.id] = console.returned_value\r\n                            text = text .. '\\n' .. console.header_bb .. \"<added '\" .. da.id .. \"'>[-]\"\r\n                        else\r\n                            text = text .. '\\n' .. \"<cannot add '\" .. da.id .. \"': it already exists>[-]\"\r\n                        end\r\n                    end\r\n                    console.deferred_assignment = nil\r\n                end\r\n            else\r\n                text = console.error_bb .. '<not found>[-]'\r\n            end\r\n            return text, false\r\n        end\r\n    )\r\n\r\n    console.add_admin_command('set', '['..console.option..'f] <variable> [<value>]',\r\n        \"Set variable to value.  If no value specified then the next value returned from 'call' is used.\\n\" ..\r\n            console.option ..'f  force overwrite ignoring type',\r\n        function (player, ...)\r\n            local variable = nil\r\n            local value = nil\r\n            local force = false\r\n            for _, arg in ipairs({...}) do\r\n                if type(arg) == 'string' and arg:len() > 1 and arg:sub(1, 1) == console.option then\r\n                    local c = 2\r\n                    while c <= arg:len() do\r\n                        local option = arg:sub(c, c)\r\n                        if option == \"f\" then\r\n                            force = not force\r\n                        else\r\n                            return console.error_bb .. \"<option '\" .. option .. \"' not recognized>[-]\"\r\n                        end\r\n                        c = c + 1\r\n                    end\r\n                elseif variable == nil then\r\n                    variable = tostring(arg)\r\n                else\r\n                    value = arg\r\n                end\r\n            end\r\n            if variable == nil then\r\n                return console.error_bb .. '<you must supply a variable>[-]'\r\n            end\r\n            variable = console.fill_path(variable)\r\n            local node, id, parent, found = console.node_from_path(variable)\r\n            local text = ''\r\n            if node ~= nil and found then\r\n                if value == nil then\r\n                    console.deferred_assignment = {command = 'set', parent = parent, id = id, force = force}\r\n                    text = id .. ': ' .. console.header_bb .. \"<awaiting 'call'>[-]\"\r\n                else\r\n                    console.deferred_assignment = nil\r\n                    if type(value) == 'string' and value:len() > 0  then\r\n                        if value:sub(1, 1) == console.literal then\r\n                            value = value:sub(2)\r\n                        else\r\n                            local value_node, value_id, value_parent, value_found = console.node_from_path(value)\r\n                            if value_node ~= nil and value_found then\r\n                                value = value_node\r\n                            else\r\n                                return console.error_bb .. '<not found>[-]'\r\n                            end\r\n                        end\r\n                    end\r\n                    if type(node) == 'boolean' then\r\n                        if not value or tostring(value):lower() == 'false' then\r\n                            value = false\r\n                        else\r\n                            value = true\r\n                        end\r\n                    end\r\n                    if type(node) == type(value) or force then\r\n                        parent[id] = value\r\n                        text = id .. ': ' .. console.value_bb .. tostring(parent[id]) .. '[-]'\r\n                    else\r\n                        return console.error_bb .. \"<cannot set '\" .. id .. \"': it is of type '\" .. type(node) .. \"'>[-]\"\r\n                    end\r\n                end\r\n            else\r\n                text = console.error_bb .. '<not found>[-]'\r\n            end\r\n            return text\r\n        end\r\n    )\r\n\r\n    console.add_admin_command('toggle', '<boolean>',\r\n        'Toggle specified boolean variable',\r\n        function (player, variable)\r\n            if variable == nil then\r\n                return console.error_bb .. '<you must supply variable>'\r\n            else\r\n                variable = tostring(variable)\r\n            end\r\n            local variable = console.fill_path(variable)\r\n            local node, id, parent, found = console.node_from_path(variable)\r\n            local text = ''\r\n            if node ~= nil and found then\r\n                if type(node) == 'boolean' then\r\n                    if node then\r\n                        parent[id] = false\r\n                        text = id .. ': ' .. console.value_bb .. 'false[-]'\r\n                    else\r\n                        parent[id] = true\r\n                        text = id .. ': ' .. console.value_bb .. 'true[-]'\r\n                    end\r\n                else\r\n                    text = console.error_bb .. '<can only toggle a boolean>[-]'\r\n                end\r\n            else\r\n                text = console.error_bb .. '<not found>[-]'\r\n            end\r\n            return text\r\n        end\r\n    )\r\n    console.add_admin_command('tgl', nil, nil, 'toggle')\r\n\r\n    console.add_admin_command('rm', '<variable>',\r\n        'Remove specified variable',\r\n        function (player, variable)\r\n            if variable == nil then\r\n                return console.error_bb .. '<you must supply variable>'\r\n            else\r\n                variable = tostring(variable)\r\n            end\r\n            local variable = console.fill_path(variable)\r\n            local node, id, parent, found = console.node_from_path(variable)\r\n            local text = ''\r\n            if node ~= nil and found then\r\n                parent[id] = nil\r\n                text = id .. \" removed!\"\r\n            else\r\n                text = console.error_bb .. '<not found>[-]'\r\n            end\r\n            return text\r\n        end\r\n    )\r\n    console.add_admin_command('del', nil, nil, 'rm')\r\n\r\n    console.add_admin_command('add', '<variable> [<value>]',\r\n        \"Create a variable set to value.   If no value specified then the next value returned from 'call' is used.\",\r\n        function (player, variable, value)\r\n            if variable == nil then\r\n                return console.error_bb .. '<you must supply variable>[-]'\r\n            else\r\n                variable = tostring(variable)\r\n            end\r\n            local variable = console.fill_path(variable)\r\n            local node, id, parent, found = console.node_from_path(variable)\r\n            local text = ''\r\n            if found then\r\n                return console.error_bb .. '<already exists>[-]'\r\n            elseif node == nil or id == '' then\r\n                return console.error_bb .. '<not found>[-]'\r\n            else\r\n                if value == nil then\r\n                    console.deferred_assignment = {command = 'add', parent = node, id = id}\r\n                    text = id .. ': ' .. console.header_bb .. \"<awaiting 'call'>[-]\"\r\n                else\r\n                    console.deferred_assignment = nil\r\n                    if type(value) == 'string' and value:len() > 0  then\r\n                        if value:sub(1, 1) == console.literal then\r\n                            value = value:sub(2)\r\n                        else\r\n                            local value_node, value_id, value_parent, value_found = console.node_from_path(value)\r\n                            if value_node ~= nil and value_found then\r\n                                value = value_node\r\n                            else\r\n                                return console.error_bb .. '<not found>[-]'\r\n                            end\r\n                        end\r\n                    end\r\n                    node[id] = value\r\n                    text = id .. ': ' .. console.value_bb .. tostring(value) .. '[-]'\r\n                end\r\n            end\r\n            return text\r\n        end\r\n    )\r\n\r\n    console.add_admin_command('exec', '['..console.option..'?qsv] <commands>',\r\n        'Execute a series of commands held in a string: commands are seperated by a new line or '..console.command_seperator,\r\n        function (player, ...)\r\n            local help_details = console.option..'q    quiet: will not output anything except final output\\n' ..\r\n                                 console.option..'s    silent: will not output anything at all\\n'..\r\n                                 console.option..'v    verbose: will output commands as they execute\\n'\r\n            local commands = nil\r\n            local verbose = false\r\n            local quiet = false\r\n            local silent = false\r\n            for _, arg in ipairs({...}) do\r\n                if type(arg) == 'string' and arg:len() > 1 and arg:sub(1,1) == console.option then\r\n                    local c = 2\r\n                    while c <= arg:len() do\r\n                        local option = arg:sub(c,c)\r\n                        if option == '?' then\r\n                            return help_details\r\n                        elseif option == 'q' then\r\n                            quiet = not quiet\r\n                        elseif option == 's' then\r\n                            silent = not silent\r\n                        elseif option == 'v' then\r\n                            verbose = not verbose\r\n                        else\r\n                            return console.error_bb .. \"<option '\" .. option .. \"' not recognized>\"\r\n                        end\r\n                        c = c + 1\r\n                    end\r\n                elseif commands == nil then\r\n                    commands = tostring(arg)\r\n                end\r\n            end\r\n            if silent then quiet = true end\r\n            if commands:len() > 1 and commands:sub(1, 1) == console.literal then\r\n                commands = commands:sub(2)\r\n            else\r\n                local variable = console.fill_path(commands)\r\n                local node, id, parent, found = console.node_from_path(variable)\r\n                if node ~= nil and found then\r\n                    commands = node\r\n                else\r\n                    return console.error_bb .. '<not found>[-]'\r\n                end\r\n            end\r\n            if commands:find('\\n') then\r\n                commands = console.split(commands, '\\n')\r\n            else\r\n                commands = console.split(commands, console.command_seperator)\r\n            end\r\n            local end_result = nil\r\n            for _, command_text in ipairs(commands) do\r\n                local command = ''\r\n                local command_function = nil\r\n                local parameters = {player}\r\n                local requires_admin = false\r\n                command, command_function, parameters, requires_admin = console.get_command(command_text, player)\r\n                if command ~= '' then\r\n                    if command_function and (player.admin or not requires_admin) then\r\n                        local response, mute = command_function(unpack(parameters))\r\n                        if response ~= nil or mute ~= nil then\r\n                            if not mute and verbose and not quiet then\r\n                                printToColor('\\n'..command_text, player.color, console.command_color)\r\n                            end\r\n                            if response then\r\n                                end_result = response\r\n                                if not quiet then\r\n                                    printToColor(response, player.color, console.output_color)\r\n                                end\r\n                            end\r\n                        end\r\n                    elseif not quiet then\r\n                        if verbose then printToColor('\\n'..command_text, player.color, console.command_color) end\r\n                        printToColor(console.error_bb .. \"<command '\" .. command .. \"' not found>[-]\", player.color, console.output_color)\r\n                    end\r\n                end\r\n            end\r\n            if end_result and not silent then\r\n                printToColor(end_result, player.color, console.output_color)\r\n            end\r\n        end\r\n    )\r\n\r\n    console.add_admin_command('watch', '['..console.option..'?cgp] ['..console.option..'t#] ['..console.option..console.seperator..'<property>] [<variable>]',\r\n        'Watch a variable or object and display it whenever it changes.\\n' .. console.hidden_bb ..\r\n        'Requires you to add a '..console.function_bb..'console.update()[-] call to an ' ..\r\n        console.function_bb .. 'onUpdate[-] event in your code.[-]\\n',\r\n        function (player, ...)\r\n            local help_details = 'Call without a parameter to display watched items, or with a variable to add it to watch list.\\n' ..\r\n                                console.option..'c will clear variable if specified, or all.\\n' ..\r\n                                console.option..'g will let you specify an object by its GUID.\\n' ..\r\n                                console.option..'t# will throttle output to # seconds.\\n' ..\r\n                                console.option..console.seperator..'<property> will watch the property of the variable.\\n' ..\r\n                                console.option..'p will pause or unpause watching.\\n'\r\n            local path = nil\r\n            local clearing = false\r\n            local throttle = nil\r\n            local pause_changed = false\r\n            local by_guid = false\r\n            local parameters = {}\r\n            local labels = {}\r\n            local property = nil\r\n            for _, arg in ipairs({...}) do\r\n                if type(arg) == 'string' and arg:len() > 1 and arg:sub(1,1) == console.option then\r\n                    local c = 2\r\n                    while c <= arg:len() do\r\n                        local option = arg:sub(c,c)\r\n                        if option == '?' then\r\n                            return help_details\r\n                        elseif option == 'c' then\r\n                            clearing = not clearing\r\n                        elseif option == 'p' then\r\n                            pause_changed = not pause_changed\r\n                        elseif option == 'g' then\r\n                            by_guid = not by_guid\r\n                        elseif option == console.seperator then\r\n                            if arg:len() > c then\r\n                                property = arg:sub(c + 1)\r\n                                c = arg:len() + 1\r\n                            end\r\n                        elseif option == 't' then\r\n                            local n = ''\r\n                            local j = c + 1\r\n                            while j <= arg:len() do\r\n                                local char = arg:sub(j, j)\r\n                                if char:match('[0-9.]') then\r\n                                    n = n .. char\r\n                                else\r\n                                    break\r\n                                end\r\n                                j = j + 1\r\n                            end\r\n                            c = j - 1\r\n                            if n == '' then\r\n                                return console.error_bb .. '<you must provide a throttle duration (in seconds)>[-]'\r\n                            else\r\n                                throttle = tonumber(n)\r\n                            end\r\n                        else\r\n                            return console.error_bb .. \"<option '\" .. option .. \"' not recognized>\"\r\n                        end\r\n                        c = c + 1\r\n                    end\r\n                else\r\n                    if path == nil then\r\n                        path = tostring(arg)\r\n                    else\r\n                        local label = tostring(arg)\r\n                        if type(arg) == 'string' then\r\n                            if arg:len() > 2 and arg:sub(1,1) == console.literal then\r\n                                arg = arg:sub(2)\r\n                                label = arg\r\n                            else\r\n                                local node, id, parent, found = console.node_from_path(console.fill_path(arg))\r\n                                if node ~= nil and found then\r\n                                    arg = node\r\n                                end\r\n                            end\r\n                        end\r\n                        table.insert(labels, label)\r\n                        table.insert(parameters, arg)\r\n                    end\r\n                end\r\n            end\r\n            local text = ''\r\n            if pause_changed then\r\n                if console.watch_list_paused then\r\n                    console.watch_list_paused = nil\r\n                    text = text .. console.header_bb .. '<unpaused>[-]'\r\n                else\r\n                    console.watch_list_paused = true\r\n                    text = text .. console.header_bb .. '<paused>[-]'\r\n                end\r\n            end\r\n            if path == nil then\r\n                if throttle ~= nil then\r\n                    text = text .. '\\n' .. console.error_bb .. '<you must provide a variable or object>[-]'\r\n                elseif by_guid then\r\n                    text = text .. '\\n' .. console.error_bb .. '<you must provide a GUID>[-]'\r\n                elseif clearing then\r\n                    console.watch_list = nil\r\n                    console.watch_list_paused = nil\r\n                    text = text .. '\\nWatch list cleared!'\r\n                elseif not pause_changed then\r\n                    if console.watch_list then\r\n                        local watched = {}\r\n                        for label, watch in pairs(console.watch_list) do\r\n                            if watch.player == player.color then\r\n                                table.insert(watched, label)\r\n                            end\r\n                        end\r\n                        table.sort(watched)\r\n                        text = text .. '\\n'..console.header_bb..'Watching:[-]'\r\n                        for _, label in ipairs(watched) do\r\n                            local watch = console.watch_list[label]\r\n                            local is_guid = (label:len() == 6 and label:sub(1,1) ~= console.seperator)\r\n                            local node, id, parent, found\r\n                            local prefix\r\n                            text = text .. '\\n'\r\n                            if is_guid then\r\n                                prefix =  console.format_guid(label)\r\n                                node = getObjectFromGUID(label)\r\n                                found = tostring(node) ~= 'null'\r\n                            else\r\n                                prefix = label\r\n                                node, id, parent, found = console.node_from_path(label)\r\n                            end\r\n                            if node ~= nil and found then\r\n                                if type(node) == 'userdata' then\r\n                                    prefix = console.object_bb .. prefix .. '[-]'\r\n                                    local position = node.getPosition()\r\n                                    local rotation = node.getRotation()\r\n                                    local p = function (x) return math.floor(x * 100) * 0.01 end\r\n                                    local r = function (x) return math.floor(x + 0.5) end\r\n                                    text = text .. prefix .. console.value_bb .. ' ∡ '..r(rotation.x)..' '..r(rotation.y)..' '..r(rotation.z) .. '[-]'..\r\n                                            console.boolean_bb..'   ⊞  '..p(position.x)..'   '..p(position.y)..'   '..p(position.z)\r\n                                elseif type(node) == 'function' then\r\n                                    local result = node(unpack(console.watch_list[label].parameters))\r\n                                    if watch.property and (type(result) == 'table' or type(result) == 'userdata') then\r\n                                        result = result[watch.property]\r\n                                        if type(result) == 'function' then\r\n                                            result = result()\r\n                                        end\r\n                                    end\r\n                                    result = tostring(result)\r\n                                    if watch.propery and watch.property:lower():find('guid') then\r\n                                        result = console.format_guid(result)\r\n                                    end\r\n                                    if result:len() > console.crop_string_at then result = result:sub(1, console.crop_string_at) .. '...' end\r\n                                    text = text .. watch.label .. console.value_bb .. result .. '[-]'\r\n                                else\r\n                                    if type(node) == 'boolean' then\r\n                                        if node then\r\n                                            node = 'true'\r\n                                        else\r\n                                            node = 'false'\r\n                                        end\r\n                                    elseif type(node) == 'string' then\r\n                                        if node:len() > console.crop_string_at then node = node:sub(1, console.crop_string_at):gsub('\\n', ' ') .. '...' end\r\n                                    end\r\n                                    text = text .. prefix .. ': ' .. console.value_bb .. node .. '[-]'\r\n                                end\r\n                            end\r\n                        end\r\n                    else\r\n                        text = text .. \"\\nWatch list is empty.\"\r\n                    end\r\n                end\r\n            else\r\n                if not by_guid then\r\n                    path = console.fill_path(path)\r\n                end\r\n                if clearing then\r\n                    local node, id, parent, found\r\n                    if not by_guid then\r\n                        node, id, parent, found, path = console.node_from_path(path)\r\n                    end\r\n                    if console.watch_list[path] then\r\n                        console.watch_list[path] = nil\r\n                        if next(console.watch_list) == nil then\r\n                            console.watch_list = nil\r\n                        end\r\n                        text = text .. '\\n' .. console.header_bb.. 'No longer watching:[-] ' .. path\r\n                    else\r\n                        text = text .. '\\n' .. console.error_bb .. '<not found>[-]'\r\n                    end\r\n                else\r\n                    local node, id, parent, found\r\n                    if by_guid then\r\n                        node = getObjectFromGUID(path)\r\n                        found = tostring(node) ~= 'null'\r\n                    else\r\n                        node, id, parent, found, path = console.node_from_path(path)\r\n                    end\r\n                    if node ~= nil and found then\r\n                        if console.watch_list == nil then console.watch_list = {} end\r\n                        if throttle == nil then throttle = 0 end\r\n                        console.watch_list[path] = {player=player.color, throttle=throttle, last_check=0, property=property}\r\n                        if type(node) == 'userdata' then\r\n                            console.watch_list[path].position = node.getPosition()\r\n                            console.watch_list[path].rotation = node.getRotation()\r\n                            console.watch_list[path].is_guid  = by_guid\r\n                        elseif type(node) == 'function' then\r\n                            console.watch_list[path].parameters = parameters\r\n                            console.watch_list[path].value = node\r\n                            console.watch_list[path].label = console.function_bb .. path .. '[-]'\r\n                            if property then\r\n                                console.watch_list[path].label = console.watch_list[path].label .. console.seperator .. property\r\n                            end\r\n                            for _, label in ipairs(labels) do\r\n                                console.watch_list[path].label = console.watch_list[path].label .. ' ' .. console.hidden_bb .. label .. '[-]'\r\n                            end\r\n                            console.watch_list[path].label = console.watch_list[path].label .. ': '\r\n                        else\r\n                            console.watch_list[path].value = node\r\n                        end\r\n                        if by_guid then\r\n                            path = console.format_guid(path)\r\n                        end\r\n                        text = text .. '\\n' .. console.header_bb .. 'Watching:[-] ' .. path\r\n                    else\r\n                        text = text .. '\\n' .. console.error_bb .. '<not found>[-]'\r\n                    end\r\n                end\r\n            end\r\n            if text:len() > 1 and text:sub(1, 1) == '\\n' then\r\n                text = text:sub(2)\r\n            end\r\n            return text\r\n        end\r\n    )\r\n\r\n    console.add_player_command('shout', '<text>',\r\n        'Broadcast <text> to all players. Colour a section with {RRGGBB}section{-}.',\r\n        function (player, ...)\r\n            local text = player.steam_name .. ': '\r\n            local space = ''\r\n            for _, word in ipairs({...}) do\r\n                text = text .. space .. tostring(word)\r\n                space = ' '\r\n            end\r\n            text = text:gsub('{','[')\r\n            text = text:gsub('}',']')\r\n            broadcastToAll(text, stringColorToRGB(player.color))\r\n            return nil, false\r\n        end\r\n    )\r\n\r\n    -- change the command help color so client added commands appear different to console++\r\n    console.set_command_listing_bb('[A0F0C0]')\r\nend\r\n\nend)\n__bundle_register(\"Console/console\", function(require, _LOADED, __bundle_register, __bundle_modules)\nif not console then\r\n    console = {}\r\n\r\n    -- Change these values as you wish\r\n    console.command_char = '>'\r\n    console.option       = '-'\r\n    console.prompt_color  = {r = 0.8,  g = 1.0,  b = 0.8 }\r\n    console.command_color = {r = 0.8,  g = 0.6,  b = 0.8 }\r\n    console.output_color  = {r = 0.88, g = 0.88, b = 0.88}\r\n    console.invalid_color = {r = 1.0,  g = 0.2,  b = 0.2 }\r\n    console.header_bb       = '[EECCAA]'\r\n    console.error_bb        = '[FF9999]'\r\n    console.inbuilt_help_bb = '[E0E0E0]'\r\n    console.client_help_bb  = '[C0C0FF]'\r\n\r\n    -- Exposed methods:\r\n\r\n    function console.add_validation_function(validation_function)\r\n        -- Adds a validation function all chat will be checked against:\r\n        -- function(string message) which returns (boolean valid, string response)\r\n        -- If all validation functions return <valid> as true the message will be displayed.\r\n        -- If one returns <valid> as false then its <response> will be displayed to that player instead.\r\n        table.insert(console.validation_functions, validation_function)\r\n    end\r\n\r\n    function console.add_player_command(command, parameter_text, help_text, command_function, default_parameters)\r\n        -- Adds a command anyone can use, see below for details\r\n        console.add_command(command, false, parameter_text, help_text, command_function, default_parameters)\r\n    end\r\n\r\n    function console.add_admin_command(command, parameter_text, help_text, command_function, default_parameters)\r\n        -- Adds a command only admins can use, see below for details\r\n        console.add_command(command, true, parameter_text, help_text, command_function, default_parameters)\r\n    end\r\n\r\n    function console.add_command(command, requires_admin, parameter_text, help_text, command_function, default_parameters)\r\n        -- Adds a command to the console.\r\n        -- command_function must take <player> as its first argument, and then any\r\n        --   subsequent arguments you wish which will be provided by the player.\r\n        -- You may alias an already-present command by calling this with command_function set to\r\n        --   the command string instead of a function.  default_parameters can be set for the alias.\r\n        -- See basic built-in commands at the bottom of this file for examples.\r\n        local commands = console.commands\r\n        local command_function = command_function\r\n        local help_text = help_text\r\n        local parameter_text = parameter_text\r\n        if type(command_function) == 'string' then --alias\r\n            if help_text == nil then\r\n                help_text = commands[command_function].help_text\r\n            end\r\n            if parameter_text == nil then\r\n                parameter_text = commands[command_function].parameter_text\r\n            end\r\n            command_function = commands[command_function].command_function\r\n        end\r\n        console.commands[command] = {\r\n            command_function   = command_function,\r\n            requires_admin     = requires_admin,\r\n            parameter_text     = parameter_text,\r\n            help_text          = help_text,\r\n            help_bb            = console.command_help_bb,\r\n            default_parameters = default_parameters,\r\n        }\r\n    end\r\n\r\n    function console.set_command_listing_bb(bb)\r\n        -- Tags commands added after with a bb color for when they are displayed (i.e. with 'help')\r\n        console.command_help_bb = bb\r\n    end\r\n\r\n    function console.disable()\r\n        -- Disables console for command purposes, but leaves validation functions running\r\n        console.active = false\r\n    end\r\n\r\n    function console.enable()\r\n        -- Enables console commands (console commands are on by default)\r\n        console.active = true\r\n    end\r\n\r\n    -- End of exposed methods.  You shouldn't need to interact with anything below (under normal circumstances)\r\n\r\n\r\n    console.active = true\r\n    console.in_command_mode = {}\r\n    console.commands = {}\r\n    console.validation_functions = {}\r\n    console.set_command_listing_bb(console.inbuilt_help_bb)\r\n\r\n    function onChat(message, player)\r\n        if message ~= '' then\r\n            local command = ''\r\n            local command_function = nil\r\n            local parameters = {player}\r\n            local requires_admin = false\r\n            local command_mode = console.in_command_mode[player.steam_id]\r\n            if command_mode and console.active then\r\n                command, command_function, parameters, requires_admin = console.get_command(message, player)\r\n            elseif message:sub(1, 1) == console.command_char and console.active then\r\n                if message:len() > 1 then\r\n                    command, command_function, parameters, requires_admin = console.get_command(message:sub(2), player)\r\n                else\r\n                    command, command_function, parameters, requires_admin = console.get_command(console.command_char, player)\r\n                end\r\n            else\r\n                for i, f in ipairs(console.validation_functions) do\r\n                    local valid, response = f(message)\r\n                    if response == nil then response = '' end\r\n                    if not valid then\r\n                        printToColor(response, player.color, console.invalid_color)\r\n                        return false\r\n                    end\r\n                end\r\n                return true\r\n            end\r\n            if console.active then\r\n                if command_function and (player.admin or not requires_admin) then\r\n                    if command_mode then\r\n                        message = console.command_char .. console.command_char .. message\r\n                    end\r\n                    local response, mute = command_function(unpack(parameters))\r\n                    if response ~= nil or mute ~= nil then\r\n                        if not mute then\r\n                            printToColor('\\n'..message, player.color, console.command_color)\r\n                        end\r\n                        if response then\r\n                            printToColor(response, player.color, console.output_color)\r\n                        end\r\n                    end\r\n                    if console.in_command_mode[player.steam_id] then console.display_prompt(player) end\r\n                    return false\r\n                else\r\n                    printToColor('\\n'..message, player.color, console.command_color)\r\n                    printToColor(console.error_bb .. \"<command '\" .. command .. \"' not found>[-]\", player.color, console.output_color)\r\n                    return false\r\n                end\r\n            end\r\n        end\r\n    end\r\n\r\n    function console.get_command(message, player)\r\n        local command_name = ''\r\n        local command_function = nil\r\n        local requires_admin = false\r\n        local parameters = {player}\r\n        for i, part in ipairs(console.split(message)) do\r\n            if i == 1 then\r\n                command_name = part\r\n                local command = console.commands[command_name]\r\n                if command then\r\n                    command_function = command.command_function\r\n                    requires_admin = command.requires_admin\r\n                    if command.default_parameters then\r\n                        for _, parameter in ipairs(command.default_parameters) do\r\n                            table.insert(parameters, parameter)\r\n                        end\r\n                    end\r\n                end\r\n            else\r\n                table.insert(parameters, part)\r\n            end\r\n        end\r\n        return command_name, command_function, parameters, requires_admin\r\n    end\r\n\r\n    function console.display_prompt(player)\r\n        printToColor(console.command_char..console.command_char, player.color, console.prompt_color)\r\n    end\r\n\r\n    function console.split(text, split_on)\r\n        local split_on = split_on or ' '\r\n        if type(split_on) == 'string' then\r\n            local s = {}\r\n            for c = 1, split_on:len() do\r\n                s[split_on:sub(c,c)] = true\r\n            end\r\n            split_on = s\r\n        end\r\n        local parts = {}\r\n        if text ~= '' then\r\n            local make_table = function(s)\r\n                local entries = console.split(s, ' ,')\r\n                local t = {}\r\n                for _, entry in ipairs(entries) do\r\n                    if type(entry) == 'string' and entry:find('=') then\r\n                        e = console.split(entry, '=')\r\n                        t[e[1]] = e[2]\r\n                    else\r\n                        table.insert(t, entry)\r\n                    end\r\n                end\r\n                return t\r\n            end\r\n            local current_split_on = split_on\r\n            local adding = false\r\n            local part = \"\"\r\n            local totype = tonumber\r\n            for c = 1, text:len() do\r\n                local char = text:sub(c, c)\r\n                if adding then\r\n                    if current_split_on[char] then -- ended current part\r\n                        if totype(part) ~= nil then\r\n                            table.insert(parts, totype(part))\r\n                        else\r\n                            table.insert(parts, part)\r\n                        end\r\n                        adding = false\r\n                        current_split_on = split_on\r\n                        totype = tonumber\r\n                    else\r\n                        part = part .. char\r\n                    end\r\n                else\r\n                    if not current_split_on[char] then -- found start of part\r\n                        if char == \"'\" then\r\n                            current_split_on = {[\"'\"] = true}\r\n                            totype = tostring\r\n                            part = ''\r\n                        elseif char == '\"' then\r\n                            current_split_on = {['\"'] = true}\r\n                            totype = tostring\r\n                            part = ''\r\n                        elseif char == '{' then\r\n                            current_split_on = {['}'] = true}\r\n                            totype = make_table\r\n                            part = ''\r\n                        else\r\n                            part = char\r\n                        end\r\n                        adding = true\r\n                    end\r\n                end\r\n            end\r\n            if adding then\r\n                if totype(part) ~= nil then\r\n                    table.insert(parts, totype(part))\r\n                else\r\n                    table.insert(parts, part)\r\n                end\r\n            end\r\n        end\r\n        return parts\r\n    end\r\n\r\n\r\n    -- Add basic built-in console commands\r\n\r\n    console.add_player_command('help', '[' .. console.option .. 'all|<command>]',\r\n        'Display available commands or help on all commands or help on a specific command.',\r\n        function (player, command)\r\n            if command ~= nil then\r\n                command = tostring(command)\r\n            end\r\n            local make_help = function (command)\r\n                return console.header_bb .. command .. ' ' .. console.commands[command].parameter_text ..\r\n                        '[-]\\n' .. console.commands[command].help_text\r\n            end\r\n            local info_mode = false\r\n            if command == console.option..'all' then\r\n                info_mode = true\r\n            end\r\n            if command and console.commands[command] then\r\n                return make_help(command)\r\n            elseif command and not info_mode then\r\n                return console.error_bb .. \"<command '\" .. command .. \"' not found>[-]\"\r\n            else\r\n                local msg = console.header_bb .. 'Available commands:[-]'\r\n                local command_list = {}\r\n                for c, _ in pairs(console.commands) do\r\n                    if player.admin or not console.commands[c].requires_admin then\r\n                        if info_mode then\r\n                            table.insert(command_list, make_help(c))\r\n                        else\r\n                            table.insert(command_list, c)\r\n                        end\r\n                    end\r\n                end\r\n                table.sort(command_list)\r\n                local sep\r\n                if info_mode then\r\n                    sep = '\\n\\n'\r\n                else\r\n                    sep = '\\n'\r\n                end\r\n                for _, c in ipairs(command_list) do\r\n                    local cmd = console.commands[c]\r\n                    if cmd then\r\n                        msg = msg .. sep .. cmd.help_bb .. c .. '[-]'\r\n                    else\r\n                        msg = msg .. sep .. c\r\n                    end\r\n                    if not info_mode then sep = ', ' end\r\n                end\r\n                return msg\r\n            end\r\n        end\r\n    )\r\n    console.add_player_command('?', nil, nil, 'help')\r\n    console.add_player_command('info', '', 'Display help on all available commands.', 'help', {console.option..'all'})\r\n\r\n    console.add_player_command('exit', '',\r\n        \"Leave <command mode> ('\" .. console.command_char .. \"' does the same).\",\r\n        function (player)\r\n            console.in_command_mode[player.steam_id] = nil\r\n            return console.header_bb .. '<command mode: off>[-]'\r\n        end\r\n    )\r\n\r\n    console.add_player_command('cmd', '',\r\n        \"Enter <command mode> ('\" .. console.command_char .. \"' does the same).\",\r\n        function (player)\r\n            console.in_command_mode[player.steam_id] = true\r\n            return console.header_bb .. '<command mode: on>[-]'\r\n        end\r\n    )\r\n\r\n    console.add_player_command(console.command_char, '',\r\n        'Toggle <command mode>',\r\n        function (player)\r\n            console.in_command_mode[player.steam_id] = not console.in_command_mode[player.steam_id]\r\n            if console.in_command_mode[player.steam_id] then\r\n                return console.header_bb .. '<command mode: on>[-]', true\r\n            else\r\n                return console.header_bb .. '<command mode: off>[-]', true\r\n            end\r\n        end\r\n    )\r\n\r\n    console.add_player_command('=', '<expression>',\r\n        'Evaluate an expression',\r\n        function (player, ...)\r\n            local expression = ''\r\n            for _, arg in ipairs({...}) do\r\n                expression = expression .. ' ' .. tostring(arg)\r\n            end\r\n            if not player.admin then\r\n                expression = expression:gasub('[a-zA-Z~]', '')\r\n            end\r\n            console.returned_value = dynamic.eval(expression)\r\n            return console.returned_value\r\n        end\r\n    )\r\n\r\n    console.add_player_command('echo', '<text>',\r\n        'Display text on screen',\r\n        function (player, ...)\r\n            local text = ''\r\n            for _, arg in ipairs({...}) do\r\n                text = text .. ' ' .. tostring(arg)\r\n            end\r\n            printToColor(text, player.color, console.output_color)\r\n            return false\r\n        end\r\n    )\r\n\r\n    console.add_player_command('cls', '',\r\n        'Clear console text',\r\n        function (player)\r\n            return '\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n' ..\r\n                   '\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n'\r\n        end\r\n    )\r\n\r\n    console.add_player_command('alias', '<alias> <command> [<parameter>...]',\r\n        'Create a command alias.',\r\n        function (player, ...)\r\n            local alias\r\n            local command\r\n            local parameters = {}\r\n            for i, arg in ipairs({...}) do\r\n                if i == 1 then\r\n                    alias = tostring(arg)\r\n                elseif i == 2 then\r\n                    command = tostring(arg)\r\n                else\r\n                    table.insert(parameters, arg)\r\n                end\r\n            end\r\n            if not alias then\r\n                return console.error_bb .. '<must provide an alias>[-]'\r\n            --elseif console.commands[alias] ~= nil then\r\n            --    return console.error_bb .. \"<command '\" .. alias .. \"' already exists!>[-]\"\r\n            elseif command == nil then\r\n                return console.error_bb .. \"<must provide a command>[-]\"\r\n            elseif console.commands[command] == nil then\r\n                return console.error_bb .. \"<command '\" .. command .. \"' does not exist>[-]\"\r\n            else\r\n                local text = console.header_bb .. alias .. '[-] = ' .. command\r\n                local help_text = console.commands[command].help_text\r\n                if not help_text:find('\\nAliased to: ') then\r\n                    help_text = help_text .. '\\nAliased to: ' .. command\r\n                end\r\n                local combined_parameters = {}\r\n                if console.commands[command].default_parameters then\r\n                    for _, parameter in ipairs(console.commands[command].default_parameters) do\r\n                        table.insert(combined_parameters, parameter)\r\n                    end\r\n                end\r\n                for _, parameter in ipairs(parameters) do\r\n                    table.insert(combined_parameters, parameter)\r\n                    text = text .. ' ' .. parameter\r\n                    help_text = help_text .. ' ' .. parameter\r\n                end\r\n                console.add_command(alias, console.commands[command].requires_admin, console.commands[command].parameter_text, help_text, command, combined_parameters)\r\n                return text\r\n            end\r\n        end\r\n    )\r\n\r\n    -- change the command help color so client added commands appear different to in-built\r\n    console.set_command_listing_bb(console.client_help_bb)\r\nend\r\n\nend)\nreturn __bundle_require(\"Global.-1.lua\")",
+  "LuaScript": "-- Bundled by luabundle {\"rootModuleName\":\"Global.-1.lua\",\"version\":\"1.6.0\"}\nlocal __bundle_require, __bundle_loaded, __bundle_register, __bundle_modules = (function(superRequire)\n\tlocal loadingPlaceholder = {[{}] = true}\n\n\tlocal register\n\tlocal modules = {}\n\n\tlocal require\n\tlocal loaded = {}\n\n\tregister = function(name, body)\n\t\tif not modules[name] then\n\t\t\tmodules[name] = body\n\t\tend\n\tend\n\n\trequire = function(name)\n\t\tlocal loadedModule = loaded[name]\n\n\t\tif loadedModule then\n\t\t\tif loadedModule == loadingPlaceholder then\n\t\t\t\treturn nil\n\t\t\tend\n\t\telse\n\t\t\tif not modules[name] then\n\t\t\t\tif not superRequire then\n\t\t\t\t\tlocal identifier = type(name) == 'string' and '\\\"' .. name .. '\\\"' or tostring(name)\n\t\t\t\t\terror('Tried to require ' .. identifier .. ', but no such module has been registered')\n\t\t\t\telse\n\t\t\t\t\treturn superRequire(name)\n\t\t\t\tend\n\t\t\tend\n\n\t\t\tloaded[name] = loadingPlaceholder\n\t\t\tloadedModule = modules[name](require, loaded, register, modules)\n\t\t\tloaded[name] = loadedModule\n\t\tend\n\n\t\treturn loadedModule\n\tend\n\n\treturn require, loaded, register, modules\nend)(nil)\n__bundle_register(\"Global.-1.lua\", function(require, _LOADED, __bundle_register, __bundle_modules)\nrequire(\"src.index\")\nend)\n__bundle_register(\"src.index\", function(require, _LOADED, __bundle_register, __bundle_modules)\n-- [Console++](https://tts-vscode.rolandostar.com/extension/console++)\nrequire(\"vscode.console\")\n-- Project Modules: Put all modules here for easy development\nlocal colors = require(\"src.consts.colors\")\nlocal guids = require(\"src.consts.guids\")\nlocal objects = require(\"src.consts.objects\")\nlocal log = require(\"src.utils.log\")\nlocal utils = require(\"src.utils.utils\")\nrequire(\"src.config\")\nlocal setup = require(\"src.setup\")\nlocal start = require(\"src.start\")\nlocal params = require(\"src.consts.params\")\nlocal metadata = require(\"src.consts.metadata\")\nlocal msgCounter = require(\"src.msgCounter\")\nlocal create = require(\"src.create\")\n-- Spawn objects\nlocal seatedPlayerObjectParams = utils.subsetByKeys(params, getSeatedPlayers())\nlocal guidToAttributes = create.objectsFromParams(seatedPlayerObjectParams)\nlocal attributesToGuid = create.attributesToGuid(guidToAttributes)\n-- Event handlers\nlocal zoneHandlers = {\n\t[\"msgDeck\"] = function(zone)\n\t\tmsgCounter.updateMsgFreqDisplay(zone, metadata.actCard, attributesToGuid, guidToAttributes)\n\tend,\n\t-- Add more zone types here\n}\nlocal function handleZoneAction(zone, object)\n\tlocal zoneType = guidToAttributes[zone.getGUID()] and guidToAttributes[zone.getGUID()][\"objectType\"]\n\tif zoneType and zoneHandlers[zoneType] then\n\t\tzoneHandlers[zoneType](zone)\n\tend\nend\n-- Events\nfunction onObjectEnterZone(zone, object)\n\thandleZoneAction(zone, object)\nend\nfunction onObjectLeaveZone(zone, object)\n\thandleZoneAction(zone, object)\nend\n-- project onLoad\nfunction onLoad()\n    log.dev('onLoad')\n    setup.onLoad()\nend\n-- [External Command](https://tts-vscode.rolandostar.com/extension/onExternalCommand)\nfunction onExternalCommand(input)\n    broadcastToAll('command: '..input, colors.red)\n    if input == 'run' then\n        -- do something here for development\n    end\nend\nend)\n__bundle_register(\"src.create\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal create = {}\nlocal utils = require(\"src.utils.utils\")\n-- Spawn objects and create a mapping from GUID to attributes for game objects\n-- @param params: table containing the player and object type information\n-- @return guidToAttributes: table mapping each object's GUID to its attributes\ncreate.objectsFromParams = function(params)\n\tlocal guidToAttributes = {}\n\tfor player, objectTypes in pairs(params) do\n\t\tfor objectType, objectParams in pairs(objectTypes) do\n\t\t\tlocal object = spawnObject(objectParams)\n\t\t\tguidToAttributes[object.getGUID()] = utils.append({[\"player\"] = player, [\"objectType\"] = objectType}, objectParams)\n\t\tend\n\tend\n\treturn guidToAttributes\nend\n-- Create a mapping from attributes to GUID for game objects\n-- @param guidToAttributes: table mapping each object's GUID to its attributes\n-- @return attributesToGuid: table mapping attributes to GUID\ncreate.attributesToGuid = function(guidToAttributes)\n\tlocal attributesToGuid = {}\n\tfor guid, attributes in pairs(guidToAttributes) do\n\t\tlocal player = attributes.player\n\t\tlocal objectType = attributes.objectType\n\t\tif not attributesToGuid[player] then\n\t\t\tattributesToGuid[player] = {}\n\t\tend\n\t\tattributesToGuid[player][objectType] = guid\n\tend\n\treturn attributesToGuid\nend\nreturn create\nend)\n__bundle_register(\"src.utils.utils\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal utils = {}\nutils.contains = function(tbl, e)\n\tfor _, v in pairs(tbl) do\n\t\tif v == e then return true end\n\tend\n\treturn false\nend\nutils.length = function(tbl)\n\tlocal count = 0\n\tfor _ in pairs(tbl) do\n\t\tcount = count + 1\n\tend\n  return count\nend\nutils.randomItem = function(tbl)\n  return tbl[math.random(1, #tbl)]\nend\nutils.append = function(from_tbl, to_tbl)\n\tfor k, v in pairs(from_tbl) do\n\t\tif not to_tbl[k] then\n\t\t\tto_tbl[k] = v\n\t\tend\n\tend\n\treturn to_tbl\nend\nutils.subsetByKeys = function(tbl, keys) \n\tlocal subset = {}\n\tfor _, key in ipairs(keys) do\n\t\tsubset[key] = tbl[key]\n\tend\n\treturn subset\nend\nreturn utils\nend)\n__bundle_register(\"src.msgCounter\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal msgCounter = {}\nlocal utils = require(\"src.utils.utils\")\n-- Get specific attribute values from a metadata table\n-- @param nested_tbl: table containing nested tables\n-- @param child_key: key of a table within another table\n-- @return extract_tbl: table mapping nested_tbl's keys to the attribute value\nlocal function getValuesFromNestedTableByChildKey(nested_tbl, child_key)\n\tlocal extract_tbl = {}\n\tfor parent_key, tbl in pairs(nested_tbl) do\n\t\textract_tbl[parent_key] = nested_tbl[parent_key][child_key]\n\tend\n\treturn extract_tbl\nend\n-- Count the frequency of each value in a table\n-- @param valueTable: table containing values to be counted\n-- @return valueFreq: table mapping each unique value to its frequency\nlocal function countValueFreq(valueTable)\n\tlocal valueFreq = {}\n\tfor key, value in pairs(valueTable) do\n\t\tvalueFreq[value] = (valueFreq[value] or 0) + 1\n\tend\n\treturn valueFreq\nend\n-- Retrieve GUIDs of cards within a target zone\n-- @param targetZone: Zone object to retrieve cards from\n-- @return guids: table containing GUIDs of cards within the zone\nlocal function getCardGUIDsfromZone(targetZone)\n\tlocal guids = {}\n    for _, object in ipairs(targetZone.getObjects()) do\n        if object.getData().Name == \"Card\" then\n            table.insert(guids, object.getGUID())\n        elseif object.getData().Name == \"Deck\" then\n            for _, cardInDeck in ipairs(object.getObjects()) do\n                table.insert(guids, cardInDeck.guid)\n            end\n        end\n    end\n\treturn guids\nend\n-- Count the frequency of messages in a set of cards\n-- @param actCardMeta: table containing metadata for active cards\n-- @param guids: table containing GUIDs of cards to count messages for\n-- @return messageFreq: table mapping each message type to its frequency\nlocal function countMessage(actCardMeta, guids)\n\tlocal subsetActCardMeta = utils.subsetByKeys(actCardMeta, guids)\n\tlocal messageInfo = getValuesFromNestedTableByChildKey(subsetActCardMeta, \"message\")\n\tlocal messageFreq = countValueFreq(messageInfo)\n\treturn messageFreq\nend\n-- Update the message frequency display for a zone\n-- @param zone: Zone object to update the display for\n-- @param metadata: table containing metadata for game objects\n-- @param attributesToGuid: table mapping attributes to object GUIDs\n-- @param guidToAttributes: table mapping object GUIDs to their attributes\nmsgCounter.updateMsgFreqDisplay = function(zone, metadata, attributesToGuid, guidToAttributes)\n\tlocal msgFreq = countMessage(metadata, getCardGUIDsfromZone(zone))\n\tlocal player = guidToAttributes[zone.getGUID()][\"player\"]\n\tgetObjectFromGUID(attributesToGuid[player][\"blackMsgNumDisplay\"]).setValue(tostring(msgFreq.black or 0))\n\tgetObjectFromGUID(attributesToGuid[player][\"blueMsgNumDisplay\"]).setValue(tostring((msgFreq.blue or 0) + (msgFreq.dual or 0)))\n\tgetObjectFromGUID(attributesToGuid[player][\"redMsgNumDisplay\"]).setValue(tostring((msgFreq.red or 0) + (msgFreq.dual or 0)))\nend\nreturn msgCounter\nend)\n__bundle_register(\"src.consts.metadata\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal metadata = {}\nmetadata.actCard = {\n[\"c5bd16\"] = { message = \"black\" },\n[\"9aa160\"] = { message = \"black\" },\n[\"acf26c\"] = { message = \"black\" },\n[\"cb92ea\"] = { message = \"black\" },\n[\"ca44ae\"] = { message = \"black\" },\n[\"f3a288\"] = { message = \"black\" },\n[\"964486\"] = { message = \"black\" },\n[\"004270\"] = { message = \"black\" },\n[\"d327cf\"] = { message = \"black\" },\n[\"b0a54c\"] = { message = \"black\" },\n[\"705167\"] = { message = \"black\" },\n[\"afa320\"] = { message = \"black\" },\n[\"29e183\"] = { message = \"black\" },\n[\"eee983\"] = { message = \"black\" },\n[\"ee8727\"] = { message = \"black\" },\n[\"1e0537\"] = { message = \"black\" },\n[\"88fb48\"] = { message = \"black\" },\n[\"8738a1\"] = { message = \"black\" },\n[\"1324c7\"] = { message = \"black\" },\n[\"42fdb3\"] = { message = \"black\" },\n[\"2f9243\"] = { message = \"black\" },\n[\"7fff50\"] = { message = \"black\" },\n[\"1df492\"] = { message = \"black\" },\n[\"8200ce\"] = { message = \"black\" },\n[\"11f7cc\"] = { message = \"black\" },\n[\"0a5713\"] = { message = \"black\" },\n[\"52d575\"] = { message = \"black\" },\n[\"2d5396\"] = { message = \"black\" },\n[\"54b223\"] = { message = \"black\" },\n[\"6161eb\"] = { message = \"black\" },\n[\"51e2c5\"] = { message = \"black\" },\n[\"35a9c6\"] = { message = \"black\" },\n[\"b2717c\"] = { message = \"black\" },\n[\"8918bd\"] = { message = \"black\" },\n[\"1f6d6b\"] = { message = \"black\" },\n[\"1faa74\"] = { message = \"black\" },\n[\"64803c\"] = { message = \"black\" },\n[\"d4ebfc\"] = { message = \"black\" },\n[\"7f4d5f\"] = { message = \"black\" },\n[\"d883c6\"] = { message = \"black\" },\n[\"18ca1c\"] = { message = \"black\" },\n[\"5650fc\"] = { message = \"black\" },\n[\"d96c0d\"] = { message = \"red\" },\n[\"b2fe77\"] = { message = \"red\" },\n[\"d82ddc\"] = { message = \"red\" },\n[\"93096a\"] = { message = \"red\" },\n[\"672e50\"] = { message = \"red\" },\n[\"1fdd73\"] = { message = \"red\" },\n[\"2fa342\"] = { message = \"red\" },\n[\"bcede5\"] = { message = \"red\" },\n[\"bb0cdb\"] = { message = \"red\" },\n[\"6f2467\"] = { message = \"red\" },\n[\"b690e4\"] = { message = \"red\" },\n[\"3b33df\"] = { message = \"red\" },\n[\"d1f8bd\"] = { message = \"red\" },\n[\"24c7c1\"] = { message = \"red\" },\n[\"bdcaf5\"] = { message = \"red\" },\n[\"d690f3\"] = { message = \"red\" },\n[\"02909f\"] = { message = \"red\" },\n[\"873733\"] = { message = \"red\" },\n[\"91612f\"] = { message = \"red\" },\n[\"5cf9bc\"] = { message = \"red\" },\n[\"cc5d8c\"] = { message = \"red\" },\n[\"74bd8c\"] = { message = \"blue\" },\n[\"b18cd7\"] = { message = \"blue\" },\n[\"71fc0b\"] = { message = \"blue\" },\n[\"b76da5\"] = { message = \"blue\" },\n[\"a6982b\"] = { message = \"blue\" },\n[\"73506c\"] = { message = \"blue\" },\n[\"5de7c2\"] = { message = \"blue\" },\n[\"30014c\"] = { message = \"blue\" },\n[\"f247c1\"] = { message = \"blue\" },\n[\"959f5a\"] = { message = \"blue\" },\n[\"5ab142\"] = { message = \"blue\" },\n[\"1d62df\"] = { message = \"blue\" },\n[\"55ac2b\"] = { message = \"blue\" },\n[\"70abb1\"] = { message = \"blue\" },\n[\"341b07\"] = { message = \"blue\" },\n[\"4114b8\"] = { message = \"blue\" },\n[\"4beb3f\"] = { message = \"blue\" },\n[\"3d7eed\"] = { message = \"blue\" },\n[\"c92a44\"] = { message = \"blue\" },\n[\"0a1931\"] = { message = \"blue\" },\n[\"203fdc\"] = { message = \"blue\" },\n[\"fb9608\"] = { message = \"dual\" },\n[\"7345ee\"] = { message = \"dual\" },\n[\"516bf5\"] = { message = \"dual\" }\n}\nreturn metadata\n\nend)\n__bundle_register(\"src.consts.params\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal params = {}\nlocal colors = require(\"src.consts.colors\")\nparams[colors.white] = {\n\tblackMsgNumDisplay = {type = \"3DText\", position = {-2.85, 1.35, -8.15}, scale = {1, 1, 1}, rotation = {90, 0, 0}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tblueMsgNumDisplay = {type = \"3DText\", position = {-4.15, 1.35, -8.15}, scale = {1, 1, 1}, rotation = {90, 0, 0}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tredMsgNumDisplay = {type = \"3DText\", position = {-5.48, 1.35, -8.15}, scale = {1, 1, 1}, rotation = {90, 0, 0}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end },\n\tmsgDeck = {type = \"ScriptingTrigger\", position = {1.31, 3.84, -14.33}, scale = {1, 5.1, 1}}\n}\nparams[colors.red] = {\n\tblackMsgNumDisplay = {type = \"3DText\", position = {-17.84, 1.35, -8.15}, scale = {1, 1, 1}, rotation = {90, 0, 0}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tblueMsgNumDisplay = {type = \"3DText\", position = {-19.17, 1.35, -8.15}, scale = {1, 1, 1}, rotation = {90, 0, 0}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tredMsgNumDisplay = {type = \"3DText\", position = {-20.5, 1.35, -8.15}, scale = {1, 1, 1}, rotation = {90, 0, 0}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tmsgDeck = {type = \"ScriptingTrigger\", position = {-13.71, 3.84, -14.33}, scale = {1, 5.1, 1}}\n}\nparams[colors.pink] = {\n\tblackMsgNumDisplay = {type = \"3DText\", position = {12.17, 1.35, -8.15}, scale = {1, 1, 1}, rotation = {90, 0, 0}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tblueMsgNumDisplay = {type = \"3DText\", position = {10.84, 1.35, -8.15}, scale = {1, 1, 1}, rotation = {90, 0, 0}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tredMsgNumDisplay = {type = \"3DText\", position = {9.51, 1.35, -8.15}, scale = {1, 1, 1}, rotation = {90, 0, 0}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tmsgDeck = {type = \"ScriptingTrigger\", position = {16.35, 3.84, -14.33}, scale = {1, 5.1, 1}}\n}\nparams[colors.yellow] = {\n\tblackMsgNumDisplay = {type = \"3DText\", position = {-13.2, 1.35, 3.13}, scale = {1, 1, 1}, rotation = {90, 0, -90}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tblueMsgNumDisplay = {type = \"3DText\", position = {-13.2, 1.35, 4.46}, scale = {1, 1, 1}, rotation = {90, 0, -90}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tredMsgNumDisplay = {type = \"3DText\", position = {-13.2, 1.35, 5.79}, scale = {1, 1, 1}, rotation = {90, 0, -90}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tmsgDeck = {type = \"ScriptingTrigger\", position = {-19.36, 3.84, -0.95}, scale = {1, 5.1, 1}}\n}\nparams[colors.green] = {\n\tblackMsgNumDisplay = {type = \"3DText\", position = {-12.21, 1.35, 9.23}, scale = {1, 1, 1}, rotation = {90, 0, 180}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tblueMsgNumDisplay = {type = \"3DText\", position = {-10.88, 1.35, 9.23}, scale = {1, 1, 1}, rotation = {90, 0, 180}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tredMsgNumDisplay = {type = \"3DText\", position = {-9.55, 1.35, 9.23}, scale = {1, 1, 1}, rotation = {90, 0, 180}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tmsgDeck = {type = \"ScriptingTrigger\", position = {-16.18, 3.84, 15.34}, scale = {1, 5.1, 1}}\n}\nparams[colors.blue] = {\n\tblackMsgNumDisplay = {type = \"3DText\", position = {17.81, 1.35, 9.23}, scale = {1, 1, 1}, rotation = {90, 0, 180}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tblueMsgNumDisplay = {type = \"3DText\", position = {19.14, 1.35, 9.23}, scale = {1, 1, 1}, rotation = {90, 0, 180}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tredMsgNumDisplay = {type = \"3DText\", position = {20.47, 1.35, 9.23}, scale = {1, 1, 1}, rotation = {90, 0, 180}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tmsgDeck = {type = \"ScriptingTrigger\", position = {13.71, 3.84, 15.34}, scale = {1, 5.1, 1}}\n}\nparams[colors.purple] = {\n\tblackMsgNumDisplay = {type = \"3DText\", position = {13.2, 1.35, -2.34}, scale = {1, 1, 1}, rotation = {90, 0, 90}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tblueMsgNumDisplay = {type = \"3DText\", position = {13.2, 1.35, -3.67}, scale = {1, 1, 1}, rotation = {90, 0, 90}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tredMsgNumDisplay = {type = \"3DText\", position = {13.2, 1.35, -5}, scale = {1, 1, 1}, rotation = {90, 0, 90}, callback_function = function(spawned_object) spawned_object.TextTool.setValue(\"0\") end},\n\tmsgDeck = {type = \"ScriptingTrigger\", position = {19.47, 3.84, 1.81}, scale = {1, 5.1, 1}}\n}\nreturn params\nend)\n__bundle_register(\"src.consts.colors\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal colors = {}\n-- [TTS default color list](https://api.tabletopsimulator.com/color/#colorlist)\nlocal ttsColors = Color.list\ncolors.white = ttsColors[1]\ncolors.brown = ttsColors[2]\ncolors.red = ttsColors[3]\ncolors.orange = ttsColors[4]\ncolors.yellow = ttsColors[5]\ncolors.green = ttsColors[6]\ncolors.teal = ttsColors[7]\ncolors.blue = ttsColors[8]\ncolors.purple= ttsColors[9]\ncolors.pink = ttsColors[10]\ncolors.grey = ttsColors[11]\ncolors.black = ttsColors[12]\nreturn colors\nend)\n__bundle_register(\"src.start\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal start = {}\nlocal utils = require(\"src.utils.utils\")\nlocal colors = require(\"src.consts.colors\")\nlocal objects = require(\"src.consts.objects\")\nlocal warning_color = colors.yellow\nlocal function extractObjectsWithTag(objects, tag)\n    local objectsWithSameTag = {}\n    for _, object in ipairs(objects) do\n       if utils.contains(object.getTags(), tag) then\n            table.insert(objectsWithSameTag, object)\n       end\n    end\n    return objectsWithSameTag\nend\nlocal function hasObjects(objects)\n    return #objects > 0\nend\nlocal function numberOfHandObjects(player)\n    return #Player[player].getHandObjects(1)\nend\nlocal function areAllHandObjectsEqualToNumber(players, number)\n    for _, player in ipairs(players) do\n        if numberOfHandObjects(player) ~= number then\n            return false\n        end\n    end\n    return true\nend\nstart.createStartButton = function()\n    objects.setupButtonScriptZone().createButton({\n        click_function = 'globalStart',\n        label = \"Start\",\n        position = {0,0.8,0},\n        rotation = {0,180,0},\n        width = 500, height = 500, font_size = 150,\n        fontStyle = \"Bold\"\n    })\nend\nstart.start = function ()\n    local seatedPlayers = getSeatedPlayers()\n    if not areAllHandObjectsEqualToNumber(seatedPlayers, 0) then\n        broadcastToAll(\"[WARNING]: place any unused character cards into the 'REMOVE' deck\", warning_color)\n        return\n    end\n    for _, zone in ipairs(getObjectsWithTag(\"character_zone\")) do\n        local cardsInZone = extractObjectsWithTag(zone.getObjects(), \"scripted\")\n        if not hasObjects(cardsInZone) then\n            broadcastToAll(\"[WARNING]: place the character card you want to use in the designated character zone on your panel\", warning_color)\n            return\n        end\n    end\n    objects.actDeck().deal(2)\n    Turns.turn_color = utils.randomItem(seatedPlayers)\n    objects.setupButtonScriptZone().clearButtons()\nend\nfunction globalStart()\n    start.start()\nend\nreturn start\nend)\n__bundle_register(\"src.consts.objects\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal objects = {}\nlocal guids = require(\"src.consts.guids\")\nlocal function getObjFun(guid)\n    return function() return getObjectFromGUID(guid) end\nend\n-- Get the object by calling a function, like: objects.idDeck()\n-- Add objects by GUID using getObjFun as follows\nobjects.idDeck = getObjFun(guids.idDeck)\nobjects.charDeck = getObjFun(guids.charDeck)\nobjects.setupButtonScriptZone = getObjFun(guids.setupButtonScriptZone)\nobjects.idDeck_zone = getObjFun(guids.idDeck_zone)\nobjects.actDeck = getObjFun(guids.actDeck)\nreturn objects\nend)\n__bundle_register(\"src.consts.guids\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal guids = {}\n-- GUIDs must be added below\nguids.idDeck = \"937c8b\"\nguids.charDeck = \"30c66e\"\nguids.setupButtonScriptZone = \"2816c9\"\nguids.idDeck_zone = \"9a0b41\"\nguids.actDeck = \"4a8259\"\nreturn guids\nend)\n__bundle_register(\"src.setup\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal setup = {}\nlocal utils = require(\"src.utils.utils\")\nlocal log = require(\"src.utils.log\")\nlocal start = require(\"src.start\")\nlocal objects = require(\"src.consts.objects\")\nlocal colors = require(\"src.consts.colors\")\nlocal function getSetUpButtonParameters()\n    return {\n        click_function = 'globalSetUp',\n        function_owner = nil,\n        label = \"Set up\",\n        position = {0,0.8,0},\n        rotation = {0,180,0},\n        width = 500,\n        height = 500,\n        font_size = 150,\n        fontStyle = \"Bold\"\n    }\nend\nfunction setup.onLoad()\n    log.dev('setup.onLoad')\n    objects.setupButtonScriptZone().createButton(getSetUpButtonParameters())\nend\nlocal function moveObjectsWithoutTag(source, target, tag)\n    for _, object in ipairs(source.getObjects()) do\n        if not utils.contains(object.tags, tag) then\n            local takenObject = source.takeObject({guid = object.guid, smooth = true})\n            target.putObject(takenObject)\n        end\n    end\nend\nlocal function whosObject(object)\n    local seatedPlayers = getSeatedPlayers()\n    for _, color in ipairs(seatedPlayers) do\n        if utils.contains(object.getTags(), color) then\n            return color\n        end\n    end\nend\nlocal function distributeCardsToEachZone(deck, zones)\n    deck.shuffle()\n    for _, zone in ipairs(zones) do\n        local card = deck.takeObject()\n        card.setPosition(zone.getPosition())\n        card.setRotation(zone.getRotation())\n        card.addTag(whosObject(zone))\n    end\nend\nlocal function removeUnusedPlayerObjects()\n    -- this function assumes that target objects have corresponding tags (i.e. color name) to their owner\n    local player_colors = {colors.white, colors.red, colors.yellow, colors.green, colors.blue, colors.purple, colors.pink}\n    for _, color in ipairs(player_colors) do\n        if not utils.contains(getSeatedPlayers(), color) then\n            for _, object in ipairs(getObjectsWithTag(color)) do\n                destroyObject(object)\n            end\n        end \n    end\nend\nlocal function dealCards(deck, num)\n    deck.shuffle()\n    deck.deal(num)\nend\nsetup.setUp = function()\n    local numPlayers = utils.length(getSeatedPlayers())\n    if numPlayers < 3 or numPlayers > 7 then\n       broadcastToAll(\"[WARNING]: This game only supports 3 - 7 players\", \"Yellow\") \n       return\n    end\n    removeUnusedPlayerObjects()\n    broadcastToAll(\"[INFO]: Select a character card and put it into your panel\")\n    dealCards(objects.charDeck(), 3)\n    objects.setupButtonScriptZone().clearButtons()\n    local playerTag = \"player_\" .. tostring(numPlayers)\n    moveObjectsWithoutTag(objects.idDeck(), objects.charDeck(), playerTag)\n    distributeCardsToEachZone(objects.idDeck(), getObjectsWithTag(\"identity_zone\"))\n    -- TODO: Currently waiting for other cards to clear to avoid deck misidentification.\n    -- Needs a more robust solution to eliminate dependency on wait time.\n    Wait.time(\n        function ()\n            for _, object in ipairs(objects.idDeck_zone().getObjects()) do\n                objects.charDeck().putObject(object)\n            end\n        end,\n        0.05\n    )\n    start.createStartButton()\nend\nfunction globalSetUp()\n    setup.setUp()\nend\nreturn setup\nend)\n__bundle_register(\"src.utils.log\", function(require, _LOADED, __bundle_register, __bundle_modules)\nlocal log = {}\nfunction log.dev(message)\n    if dev then\n        print('dev: ', message)\n    end\nend\nreturn log\nend)\n__bundle_register(\"src.config\", function(require, _LOADED, __bundle_register, __bundle_modules)\n-- project configurations\ndev = true\nend)\n__bundle_register(\"vscode.console\", function(require, _LOADED, __bundle_register, __bundle_modules)\nrequire(\"Console/console++\")\r\n\r\n-- function prototype\r\nfunction onExternalCommand(command) end\r\n\r\n-- Overwrite onChat function if you rather be handled by onExternalMessage\r\n-- function onChat(message, player) end\r\n\r\nfunction onExternalMessage(data)\r\n  if data.input ~= nil then onExternalCommand(data.input) end\r\n  if data.command ~= nil then\r\n    local hostPlayer\r\n    local players = getSeatedPlayers()\r\n    for key, value in pairs(players) do\r\n      if Player[value].host then\r\n        hostPlayer = Player[value]\r\n      end\r\n    end\r\n    if data.command ~= '' then\r\n      local command = ''\r\n      local command_function = nil\r\n      local parameters = {hostPlayer}\r\n      local requires_admin = false\r\n      local command_mode = console.in_command_mode[hostPlayer.steam_id]\r\n      if command_mode and console.active then\r\n          command, command_function, parameters, requires_admin = console.get_command(data.command, hostPlayer)\r\n      elseif data.command:sub(1, 1) == console.command_char and console.active then\r\n          if data.command:len() > 1 then\r\n              command, command_function, parameters, requires_admin = console.get_command(data.command:sub(2), hostPlayer)\r\n          else\r\n              command, command_function, parameters, requires_admin = console.get_command(console.command_char, hostPlayer)\r\n          end\r\n      else\r\n          for i, f in ipairs(console.validation_functions) do\r\n              local valid, response = f(data.command)\r\n              if response == nil then response = '' end\r\n              if not valid then\r\n                  printToColor(response, hostPlayer.color, console.invalid_color)\r\n                  return false\r\n              end\r\n          end\r\n          return true\r\n      end\r\n      if console.active then\r\n          if command_function and (hostPlayer.admin or not requires_admin) then\r\n              if command_mode then\r\n                  data.command = console.command_char .. console.command_char .. data.command\r\n              end\r\n              local response, mute = command_function(unpack(parameters))\r\n              if response ~= nil or mute ~= nil then\r\n                  if not mute then\r\n                      printToColor('\\n'..data.command, hostPlayer.color, console.command_color)\r\n                  end\r\n                  if response then\r\n                      printToColor(response, hostPlayer.color, console.output_color)\r\n                  end\r\n              end\r\n              if console.in_command_mode[hostPlayer.steam_id] then console.display_prompt(hostPlayer) end\r\n              return false\r\n          else\r\n              printToColor('\\n'..data.command, hostPlayer.color, console.command_color)\r\n              printToColor(console.error_bb .. \"<command '\" .. command .. \"' not found>[-]\", hostPlayer.color, console.output_color)\r\n              return false\r\n          end\r\n      end\r\n    end\r\n  end\r\nend\r\n\nend)\n__bundle_register(\"Console/console++\", function(require, _LOADED, __bundle_register, __bundle_modules)\nrequire(\"Console/console\")\r\n\r\nif not console.plusplus then\r\n    console.plusplus = true\r\n\r\n    -- Change these values as you wish\r\n    console.seperator         = '/'\r\n    console.wildcard          = '*'\r\n    console.literal           = '`'  -- string parameters will be treated as paths where apt unless prefixed with this\r\n    console.result            = '~'  -- refers to the most recently returned result from a call\r\n    console.command_seperator = ';'  -- used in batch files to seperate commands\r\n    console.indent            = '  '\r\n    console.crop_string_at = 20\r\n    console.builtin_path = 'sys'\r\n    console.table_bb    = '[EEDD88]'\r\n    console.hidden_bb   = '[DDAAAA]'\r\n    console.function_bb = '[AADDAA]'\r\n    console.value_bb    = '[88EE88]'\r\n    console.boolean_bb  = '[CCCCFF]'\r\n    console.object_bb   = '[CCBBCC]'\r\n    console.guid_bb     = '[BBBBBB]'\r\n\r\n    console.autoexec         = ''\r\n    console.autoexec_options = '-s'\r\n\r\n    -- Exposed methods:\r\n\r\n    function console.hide_globals(label)\r\n        -- all globals present when you call this will be hidden under <label> (unless built-in or already hidden)\r\n        local hidden = {}\r\n        for global, _ in pairs(_G) do\r\n            local found = false\r\n            for _, globals in pairs(console.hidden_globals) do\r\n                if globals[global] then\r\n                    found = true\r\n                    break\r\n                end\r\n            end\r\n            if not found then\r\n                table.insert(hidden, global)\r\n            end\r\n        end\r\n        if console.hidden_globals[label] == nil then\r\n            console.hidden_globals[label] = {}\r\n        end\r\n        for _, global in ipairs(hidden) do\r\n            console.hidden_globals[label][global] = true\r\n        end\r\n    end\r\n\r\n    function console.load()\r\n        -- call this function in an onLoad event to enable the autoexec\r\n        console.cd = console.seperator\r\n        for _, player in pairs(getSeatedPlayers()) do\r\n            if Player[player].admin then\r\n                console.commands['exec'].command_function(Player[player], console.seperator..'console'..console.seperator..'autoexec', console.autoexec_options)\r\n                break\r\n            end\r\n        end\r\n    end\r\n\r\n    function console.update()\r\n        -- call this function in an onUpdate event to enable the watch list\r\n        if console.watch_list and not console.watch_list_paused then\r\n            for variable, watch in pairs(console.watch_list) do\r\n                if watch.throttle == 0 or watch.last_check + watch.throttle < os.clock() then\r\n                    watch.last_check = os.clock()\r\n                    local node, id, parent, found\r\n                    if watch.is_guid then\r\n                        node = getObjectFromGUID(variable)\r\n                        found = tostring(node) ~= 'null'\r\n                    else\r\n                        node, id, parent, found = console.node_from_path(variable)\r\n                    end\r\n                    if node ~= nil and found then\r\n                        if type(node) == 'userdata' then\r\n                            if tostring(node) ~= 'null' then\r\n                                local p = function (x) return math.floor(x * 100) * 0.01 end\r\n                                local r = function (x) return math.floor(x + 0.5) end\r\n                                local position = node.getPosition()\r\n                                local rotation = node.getRotation()\r\n                                if p(position.x) ~= p(watch.position.x) or r(rotation.x) ~= r(watch.rotation.x) or\r\n                                   p(position.y) ~= p(watch.position.y) or r(rotation.y) ~= r(watch.rotation.y) or\r\n                                   p(position.z) ~= p(watch.position.z) or r(rotation.z) ~= r(watch.rotation.z) then\r\n                                   watch.position = position\r\n                                   watch.rotation = rotation\r\n                                   node = ' ∡ '..r(rotation.x)..' '..r(rotation.y)..' '..r(rotation.z) ..\r\n                                        console.boolean_bb..'   ⊞  '..p(position.x)..'   '..p(position.y)..'   '..p(position.z)\r\n                                   if watch.is_guid then\r\n                                       variable = console.format_guid(variable)\r\n                                   else\r\n                                       variable = console.object_bb .. variable .. '[-]'\r\n                                   end\r\n                                   printToColor(variable .. console.value_bb .. node .. '[-]', watch.player, console.output_color)\r\n                                end\r\n                            end\r\n                        elseif type(node) == 'function' then\r\n                            local result = node(unpack(watch.parameters))\r\n                            if watch.property and (type(result) == 'table' or type(result) == 'userdata') then\r\n                                result = result[watch.property]\r\n                                if type(result) == 'function' then\r\n                                    result = result()\r\n                                end\r\n                            end\r\n                            if result ~= watch.value then\r\n                                watch.value = result\r\n                                result = tostring(result)\r\n                                if result:len() > console.crop_string_at then result = result:sub(1, console.crop_string_at) .. '...' end\r\n                                if result:len() == 6 and watch.label:lower():find('guid') then result = console.format_guid(result) end\r\n                                printToColor(watch.label .. console.value_bb .. result .. '[-]', watch.player, console.output_color)\r\n                            end\r\n                        else\r\n                            if node ~= watch.value then\r\n                                watch.value = node\r\n                                if type(node) == 'boolean' then\r\n                                    if node then\r\n                                        node = 'true'\r\n                                    else\r\n                                        node = 'false'\r\n                                    end\r\n                                elseif type(node) == 'string' then\r\n                                    if node:len() > console.crop_string_at then node = node:sub(1, console.crop_string_at):gsub('\\n', ' ') .. '...' end\r\n                                end\r\n                                printToColor(variable .. ': ' .. console.value_bb .. node .. '[-]', watch.player, console.output_color)\r\n                            end\r\n                        end\r\n                    end\r\n                end\r\n            end\r\n        end\r\n    end\r\n\r\n    -- simple swear-blocking validation\r\n    console.add_validation_function(\r\n        function (message)\r\n            local message = message:lower()\r\n            for i, bad_word in pairs({'fuck', 'cunt'}) do\r\n                if message:find(bad_word) then\r\n                    return false, \"No swearing!\"\r\n                end\r\n            end\r\n            return true\r\n        end\r\n    )\r\n\r\n    -- End of exposed methods.  You shouldn't need to interact with anything below (under normal circumstances)\r\n\r\n\r\n    -- override default prompt with one which displays current table\r\n    function console.display_prompt(player)\r\n        printToColor(console.cd .. ' ' .. console.command_char..console.command_char, player.color, console.prompt_color)\r\n    end\r\n\r\n\r\n    -- console++ follows\r\n\r\n    console.cd = console.seperator\r\n    console.hidden_globals = {}\r\n    console.hide_globals(console.builtin_path)\r\n\r\n    function console.is_hidden(label)\r\n        for _, globals in pairs(console.hidden_globals) do\r\n            if globals[label] then\r\n                return true\r\n            end\r\n        end\r\n        return false\r\n    end\r\n\r\n    function console.escape_bb(s)\r\n        local s = tostring(s)\r\n        if s == '' then\r\n            return ''\r\n        else\r\n            local r = ''\r\n            for c = 1, s:len() do\r\n                local char = s:sub(c, c)\r\n                if char == '[' then\r\n                    r = r .. '[\\u{200B}'\r\n                elseif char == ']' then\r\n                    r = r .. '\\u{200B}]'\r\n                else\r\n                    r = r .. char\r\n                end\r\n            end\r\n            return r\r\n        end\r\n    end\r\n\r\n    function console.format_guid(guid)\r\n        return console.guid_bb .. '⁅' .. guid .. '⁆[-]'\r\n    end\r\n\r\n    function console.fill_path(path)\r\n        local path = path\r\n        local filter = nil\r\n        if path == nil then\r\n            return console.cd, filter\r\n        end\r\n        local c = path:len()\r\n        if path:sub(c) ~= console.seperator then\r\n            local found = false\r\n            while c > 0 do\r\n                local char = path:sub(c, c)\r\n                if char == console.wildcard then\r\n                    found = true\r\n                elseif char == console.seperator then\r\n                    break\r\n                end\r\n                c = c - 1\r\n            end\r\n            if found then\r\n                filter = '^'\r\n                for i = c + 1, path:len() do\r\n                    local char = path:sub(i, i)\r\n                    if char == console.wildcard then\r\n                        filter = filter .. '.*'\r\n                    else\r\n                        filter = filter .. char\r\n                    end\r\n                end\r\n                filter = filter .. '$'\r\n                path = path:sub(1, c)\r\n            end\r\n        end\r\n        if path:sub(1,1) == console.seperator then\r\n            return path, filter\r\n        else\r\n            return console.cd .. path, filter\r\n        end\r\n    end\r\n\r\n    function console.node_from_path(path)\r\n        local node = _G\r\n        local id = {''}\r\n        local parent = {nil}\r\n        local found = true\r\n        local depth = 0\r\n        local stack = {}\r\n        local hidden = nil\r\n        local ends_with_table = {true}\r\n        if path == 'true' then\r\n            node = true\r\n        elseif path == 'false' then\r\n            node = false\r\n        elseif path ~= console.seperator then\r\n            for i, part in ipairs(console.split(path, console.seperator)) do\r\n                if part == '..' then\r\n                    if depth > 0 then\r\n                        node = table.remove(parent)\r\n                        table.remove(id)\r\n                        table.remove(stack)\r\n                        table.remove(ends_with_table)\r\n                        depth = depth - 1\r\n                    end\r\n                elseif part == '.' then\r\n                    ; -- do nothing, . = where we are\r\n                elseif part == console.result then\r\n                    table.insert(parent, node)\r\n                    table.insert(id, part)\r\n                    table.insert(stack, part)\r\n                    node = console.returned_value\r\n                    table.insert(ends_with_table, type(node) == 'table')\r\n                    depth = depth + 1\r\n                elseif node[part] ~= nil then\r\n                    table.insert(parent, node)\r\n                    table.insert(id, part)\r\n                    table.insert(stack, part)\r\n                    node = node[part]\r\n                    table.insert(ends_with_table, type(node) == 'table')\r\n                    depth = depth + 1\r\n                elseif node == _G and console.hidden_globals[part] then\r\n                    hidden = console.hidden_globals[part]\r\n                else\r\n                    table.insert(id, part)\r\n                    found = false\r\n                    break\r\n                end\r\n            end\r\n        end\r\n        path = ''\r\n        for i, part in ipairs(stack) do\r\n            path = path .. console.seperator .. part\r\n        end\r\n        if table.remove(ends_with_table) then\r\n            path = path .. console.seperator\r\n        end\r\n        return node, table.remove(id), table.remove(parent), found, path, hidden\r\n    end\r\n\r\n\r\n    -- commands\r\n\r\n    console.add_admin_command('cd', '[<table>]',\r\n        'Display current table or change current table',\r\n        function (player, path)\r\n            if path == nil then\r\n                return console.cd\r\n            else\r\n                path = tostring(path)\r\n            end\r\n            local location = console.fill_path(path)\r\n            local node, id, parent, found, location = console.node_from_path(location)\r\n            local text = nil\r\n            if node ~= nil and found and type(node) == 'table' then\r\n                console.cd = location\r\n                if not console.in_command_mode[player.steam_id] then text = console.cd end\r\n            else\r\n                text = console.error_bb .. '<not found>[-]'\r\n            end\r\n            return text, false\r\n        end\r\n    )\r\n    console.add_admin_command('cd..', '', 'Change current table to parent table.', 'cd', {'..'})\r\n\r\n    console.add_admin_command('ls', '[' .. console.option .. '?afotv] [' .. console.option .. 'r[#]] [<table>]',\r\n        'Display variables in current table or specified table',\r\n        function (player, ...)\r\n            local help_details = console.header_bb .. 'Options[-]\\n' ..\r\n                'Show:\\n '..console.option..'f functions\\n '..console.option..'o objects\\n '..\r\n                console.option..'v variables (defaults to on)\\n '..console.option..'t tables (defaults to on)\\n '..\r\n                console.option..'a all\\n\\n' ..console.option..'r[#] recurse [# layers if specified]'\r\n            local path = console.cd\r\n            local display_functions = false\r\n            local display_objects = false\r\n            local display_variables = false\r\n            local display_tables = false\r\n            local display_all = false\r\n            local recursions_left = 0\r\n            for i, arg in ipairs({...}) do\r\n                arg = tostring(arg)\r\n                if arg:len() > 1 and arg:sub(1,1) == console.option then\r\n                    local c = 2\r\n                    while c <= arg:len() do\r\n                        local option = arg:sub(c,c)\r\n                        if option == 'f' then\r\n                            display_functions = not display_functions\r\n                        elseif option == 'o' then\r\n                            display_objects = not display_objects\r\n                        elseif option == 'v' then\r\n                            display_variables = not display_variables\r\n                        elseif option == 't' then\r\n                            display_tables = not display_tables\r\n                        elseif option == 'a' then\r\n                            display_all = not display_all\r\n                        elseif option == 'r' then\r\n                            local n = ''\r\n                            local j = c + 1\r\n                            while j <= arg:len() do\r\n                                local char = arg:sub(j, j)\r\n                                if char:match('%d') then\r\n                                    n = n .. char\r\n                                else\r\n                                    break\r\n                                end\r\n                                j = j + 1\r\n                            end\r\n                            c = j - 1\r\n                            if n == '' then\r\n                                recursions_left = 20\r\n                            else\r\n                                recursions_left = tonumber(n)\r\n                            end\r\n                        elseif option == '?' or option == 'h' then\r\n                            return help_details\r\n                        else\r\n                            return console.error_bb .. \"<option '\" .. console.option .. option .. \"' not recognized>[-]\\n\"\r\n                        end\r\n                        c = c + 1\r\n                    end\r\n                else\r\n                    path = arg\r\n                end\r\n            end\r\n            local default_variables = not (display_tables or display_objects or display_functions or display_variables)\r\n            if display_functions or display_objects or display_variables then\r\n                display_tables = not display_tables\r\n            end\r\n            if display_all then\r\n                display_functions = true\r\n                display_objects = true\r\n                display_variables = true\r\n                display_tables = true\r\n            elseif default_variables then\r\n                display_functions = false\r\n                display_objects = false\r\n                display_variables = true\r\n                display_tables = true\r\n            end\r\n            local location, filter = console.fill_path(path)\r\n            return console.ls(player, location, filter, display_functions, display_objects, display_variables, display_tables, recursions_left)\r\n        end\r\n    )\r\n    console.add_admin_command('dir', nil, nil, 'ls')\r\n    console.add_admin_command(console.result, '', \"Calls 'ls \"..console.option..\"a \"..console.result..\"'\", 'ls', {console.option..'a', console.result})\r\n\r\n    function console.ls(player, path, filter, display_functions, display_objects, display_variables, display_tables, recursions_left, indent)\r\n        local text = ''\r\n        local indent = indent or ''\r\n        local node, id, parent, found, location, hidden = console.node_from_path(path)\r\n        local paths = {}\r\n        if node ~= nil and (found or hidden) then\r\n            if type(node) == 'table' then\r\n                local tables = {}\r\n                local entries = {}\r\n                for k, v in pairs(node) do\r\n                    if (node ~= _G or (not hidden and not console.is_hidden(k)) or (hidden and hidden[k])) and (filter == nil or k:match(filter)) then\r\n                        if type(v) == 'table' then\r\n                            local t = console.table_bb .. k .. '[-]'\r\n                            table.insert(tables, t)\r\n                            paths[t] = path .. console.seperator .. k\r\n                        else\r\n                            if type(v) == 'function' then\r\n                                if display_functions then\r\n                                    table.insert(entries, console.function_bb .. k .. '[-]()')\r\n                                end\r\n                            elseif type(v) == 'userdata' then\r\n                                if display_objects then\r\n                                    local tag = tostring(v)\r\n                                    if tag:find('(LuaGameObjectScript)') and not tag:gsub('(LuaGameObjectScript)',''):find('Script ') then\r\n                                        tag = v.tag .. ' ' .. console.format_guid(v.getGUID())\r\n                                    end\r\n                                    if type(k) == 'number' and math.floor(k) == k then k = string.format('%04d', k) end\r\n                                    table.insert(entries, console.object_bb .. k .. '[-]: '  .. tag)\r\n                                end\r\n                            elseif display_variables then\r\n                                if type(v) == 'boolean' then\r\n                                    if v then\r\n                                        v = 'true'\r\n                                    else\r\n                                        v = 'false'\r\n                                    end\r\n                                    table.insert(entries, k .. ': ' .. console.boolean_bb .. v .. '[-]')\r\n                                else\r\n                                    local is_guid = false\r\n                                    if type(v) == 'string' then\r\n                                        if v:len()> console.crop_string_at then v = v:sub(1, console.crop_string_at):gsub('\\n', ' ') .. '...' end\r\n                                        if type(k) == 'string' and k:lower():find('guid') and v:len() == 6 then\r\n                                            is_guid = true\r\n                                        end\r\n                                    end\r\n                                    if is_guid then\r\n                                        table.insert(entries, k .. ': ' .. console.format_guid(v) .. '[-]')\r\n                                    else\r\n                                        table.insert(entries, k .. ': ' .. console.value_bb .. console.escape_bb(v) .. '[-]')\r\n                                    end\r\n                                end\r\n                            end\r\n                        end\r\n                    end\r\n                end\r\n                local cmp = function (a, b)\r\n                    if not a then\r\n                        return true\r\n                    elseif not b then\r\n                        return false\r\n                    else\r\n                        local la = a:len()\r\n                        local lb = b:len()\r\n                        local c = 1\r\n                        repeat\r\n                            if c > la and c <= lb then\r\n                                return true\r\n                            elseif c > lb and c <= la then\r\n                                return false\r\n                            elseif c > la then\r\n                                return false\r\n                            else\r\n                                local ba = a:sub(c, c):byte()\r\n                                local bb = b:sub(c, c):byte()\r\n                                if ba < bb then\r\n                                    return true\r\n                                elseif bb < ba then\r\n                                    return false\r\n                                end\r\n                            end\r\n                            c = c + 1\r\n                        until false\r\n                    end\r\n                end\r\n                table.sort(tables, cmp)\r\n                table.sort(entries, cmp)\r\n                local cr = ''\r\n                if display_tables then\r\n                    for i, t in ipairs(tables) do\r\n                        text = text .. cr .. indent .. t .. console.seperator\r\n                        if recursions_left ~= 0 then\r\n                            text = text .. '\\n' .. console.ls(player, paths[t], filter,\r\n                                display_functions, display_objects, display_variables, display_tables,\r\n                                recursions_left-1, indent..console.indent)\r\n                        end\r\n                        cr = '\\n'\r\n                    end\r\n                    if node == _G and not hidden then\r\n                        for label, _ in pairs(console.hidden_globals) do\r\n                            if (filter == nil or label:match(filter)) then -- and label ~= console.builtin_path\r\n                                text = text .. cr .. indent .. console.hidden_bb .. label .. console.seperator .. '[-]'\r\n                                cr = '\\n'\r\n                            end\r\n                        end\r\n                    end\r\n                end\r\n                for _, entry in ipairs(entries) do\r\n                    text = text .. cr .. indent .. entry\r\n                    cr = '\\n'\r\n                end\r\n            elseif type(node) == 'userdata' then\r\n                local tag = tostring(node)\r\n                if tag ~= 'null' and tag:find('(LuaGameObjectScript)') and not tag:gsub('(LuaGameObjectScript)',''):find('Script ') then\r\n                    tag = node.tag .. ' ' .. console.format_guid(node.getGUID())\r\n                end\r\n                text = indent .. console.object_bb .. id .. '[-]: ' .. tag\r\n            elseif type(node) == 'function' then\r\n                text = indent .. console.function_bb .. id .. '[-]()'\r\n            elseif type(node) == 'boolean' then\r\n                if node then\r\n                    text = indent .. id .. ': ' .. console.boolean_bb .. 'true[-]'\r\n                else\r\n                    text = indent .. id .. ': ' .. console.boolean_bb .. 'false[-]'\r\n                end\r\n            else\r\n                if type(id) == 'string' and id:lower():find('guid') and type(node) == 'string' and node:len() == 6 then\r\n                    text = indent .. id .. ': ' .. console.format_guid(node) .. '[-]'\r\n                else\r\n                    text = indent .. id .. ': ' .. console.value_bb .. console.escape_bb(node) .. '[-]'\r\n                end\r\n            end\r\n        else\r\n            text = indent .. console.error_bb .. '<not found>[-]'\r\n        end\r\n        return text\r\n    end\r\n\r\n    console.add_admin_command('call', '<function> [<parameter>...]',\r\n        'Call function with parameters and display result.',\r\n        function (player, ...)\r\n            local path = nil\r\n            local parameters = {}\r\n            for i, arg in ipairs({...}) do\r\n                if i == 1 then\r\n                    path = tostring(arg)\r\n                else\r\n                    if type(arg) == 'string' then\r\n                        if arg:len() > 2 and arg:sub(1,1) == console.literal then\r\n                            arg = arg:sub(2)\r\n                        else\r\n                            local node, id, parent, found = console.node_from_path(console.fill_path(arg))\r\n                            if node ~= nil and found then\r\n                                arg = node\r\n                            end\r\n                        end\r\n                    end\r\n                    table.insert(parameters, arg)\r\n                end\r\n            end\r\n            if path == nil then\r\n                return console.error_bb .. '<you must supply a function>[-]'\r\n            end\r\n            local location = console.fill_path(path)\r\n            local node, id, parent, found, location = console.node_from_path(location)\r\n            local text = nil\r\n            if node ~= nil and found and type(node) == 'function' then\r\n                console.returned_value = node(unpack(parameters))\r\n                text = tostring(console.returned_value)\r\n                if console.deferred_assignment then\r\n                    local da = console.deferred_assignment\r\n                    if da.command == 'set' then\r\n                        if da.parent[da.id] ~= nil then\r\n                            if da.force or type(console.returned_value) == type(da.parent[da.id]) then\r\n                                da.parent[da.id] = console.returned_value\r\n                                text = text .. '\\n' .. console.header_bb .. \"<set '\" .. da.id .. \"'>[-]\"\r\n                            else\r\n                                text = text .. '\\n' .. console.error_bb .. \"<cannot set '\" .. da.id .. \"': it is of type '\" .. type(da.parent[da.id]) .. \"'>[-]\"\r\n                            end\r\n                        else\r\n                            text = text .. '\\n' .. console.error_bb .. \"<cannot set '\" .. da.id .. \"': it does not exist>[-]\"\r\n                        end\r\n                    elseif da.command == 'add' then\r\n                        if da.parent[da.id] == nil then\r\n                            da.parent[da.id] = console.returned_value\r\n                            text = text .. '\\n' .. console.header_bb .. \"<added '\" .. da.id .. \"'>[-]\"\r\n                        else\r\n                            text = text .. '\\n' .. \"<cannot add '\" .. da.id .. \"': it already exists>[-]\"\r\n                        end\r\n                    end\r\n                    console.deferred_assignment = nil\r\n                end\r\n            else\r\n                text = console.error_bb .. '<not found>[-]'\r\n            end\r\n            return text, false\r\n        end\r\n    )\r\n\r\n    console.add_admin_command('set', '['..console.option..'f] <variable> [<value>]',\r\n        \"Set variable to value.  If no value specified then the next value returned from 'call' is used.\\n\" ..\r\n            console.option ..'f  force overwrite ignoring type',\r\n        function (player, ...)\r\n            local variable = nil\r\n            local value = nil\r\n            local force = false\r\n            for _, arg in ipairs({...}) do\r\n                if type(arg) == 'string' and arg:len() > 1 and arg:sub(1, 1) == console.option then\r\n                    local c = 2\r\n                    while c <= arg:len() do\r\n                        local option = arg:sub(c, c)\r\n                        if option == \"f\" then\r\n                            force = not force\r\n                        else\r\n                            return console.error_bb .. \"<option '\" .. option .. \"' not recognized>[-]\"\r\n                        end\r\n                        c = c + 1\r\n                    end\r\n                elseif variable == nil then\r\n                    variable = tostring(arg)\r\n                else\r\n                    value = arg\r\n                end\r\n            end\r\n            if variable == nil then\r\n                return console.error_bb .. '<you must supply a variable>[-]'\r\n            end\r\n            variable = console.fill_path(variable)\r\n            local node, id, parent, found = console.node_from_path(variable)\r\n            local text = ''\r\n            if node ~= nil and found then\r\n                if value == nil then\r\n                    console.deferred_assignment = {command = 'set', parent = parent, id = id, force = force}\r\n                    text = id .. ': ' .. console.header_bb .. \"<awaiting 'call'>[-]\"\r\n                else\r\n                    console.deferred_assignment = nil\r\n                    if type(value) == 'string' and value:len() > 0  then\r\n                        if value:sub(1, 1) == console.literal then\r\n                            value = value:sub(2)\r\n                        else\r\n                            local value_node, value_id, value_parent, value_found = console.node_from_path(value)\r\n                            if value_node ~= nil and value_found then\r\n                                value = value_node\r\n                            else\r\n                                return console.error_bb .. '<not found>[-]'\r\n                            end\r\n                        end\r\n                    end\r\n                    if type(node) == 'boolean' then\r\n                        if not value or tostring(value):lower() == 'false' then\r\n                            value = false\r\n                        else\r\n                            value = true\r\n                        end\r\n                    end\r\n                    if type(node) == type(value) or force then\r\n                        parent[id] = value\r\n                        text = id .. ': ' .. console.value_bb .. tostring(parent[id]) .. '[-]'\r\n                    else\r\n                        return console.error_bb .. \"<cannot set '\" .. id .. \"': it is of type '\" .. type(node) .. \"'>[-]\"\r\n                    end\r\n                end\r\n            else\r\n                text = console.error_bb .. '<not found>[-]'\r\n            end\r\n            return text\r\n        end\r\n    )\r\n\r\n    console.add_admin_command('toggle', '<boolean>',\r\n        'Toggle specified boolean variable',\r\n        function (player, variable)\r\n            if variable == nil then\r\n                return console.error_bb .. '<you must supply variable>'\r\n            else\r\n                variable = tostring(variable)\r\n            end\r\n            local variable = console.fill_path(variable)\r\n            local node, id, parent, found = console.node_from_path(variable)\r\n            local text = ''\r\n            if node ~= nil and found then\r\n                if type(node) == 'boolean' then\r\n                    if node then\r\n                        parent[id] = false\r\n                        text = id .. ': ' .. console.value_bb .. 'false[-]'\r\n                    else\r\n                        parent[id] = true\r\n                        text = id .. ': ' .. console.value_bb .. 'true[-]'\r\n                    end\r\n                else\r\n                    text = console.error_bb .. '<can only toggle a boolean>[-]'\r\n                end\r\n            else\r\n                text = console.error_bb .. '<not found>[-]'\r\n            end\r\n            return text\r\n        end\r\n    )\r\n    console.add_admin_command('tgl', nil, nil, 'toggle')\r\n\r\n    console.add_admin_command('rm', '<variable>',\r\n        'Remove specified variable',\r\n        function (player, variable)\r\n            if variable == nil then\r\n                return console.error_bb .. '<you must supply variable>'\r\n            else\r\n                variable = tostring(variable)\r\n            end\r\n            local variable = console.fill_path(variable)\r\n            local node, id, parent, found = console.node_from_path(variable)\r\n            local text = ''\r\n            if node ~= nil and found then\r\n                parent[id] = nil\r\n                text = id .. \" removed!\"\r\n            else\r\n                text = console.error_bb .. '<not found>[-]'\r\n            end\r\n            return text\r\n        end\r\n    )\r\n    console.add_admin_command('del', nil, nil, 'rm')\r\n\r\n    console.add_admin_command('add', '<variable> [<value>]',\r\n        \"Create a variable set to value.   If no value specified then the next value returned from 'call' is used.\",\r\n        function (player, variable, value)\r\n            if variable == nil then\r\n                return console.error_bb .. '<you must supply variable>[-]'\r\n            else\r\n                variable = tostring(variable)\r\n            end\r\n            local variable = console.fill_path(variable)\r\n            local node, id, parent, found = console.node_from_path(variable)\r\n            local text = ''\r\n            if found then\r\n                return console.error_bb .. '<already exists>[-]'\r\n            elseif node == nil or id == '' then\r\n                return console.error_bb .. '<not found>[-]'\r\n            else\r\n                if value == nil then\r\n                    console.deferred_assignment = {command = 'add', parent = node, id = id}\r\n                    text = id .. ': ' .. console.header_bb .. \"<awaiting 'call'>[-]\"\r\n                else\r\n                    console.deferred_assignment = nil\r\n                    if type(value) == 'string' and value:len() > 0  then\r\n                        if value:sub(1, 1) == console.literal then\r\n                            value = value:sub(2)\r\n                        else\r\n                            local value_node, value_id, value_parent, value_found = console.node_from_path(value)\r\n                            if value_node ~= nil and value_found then\r\n                                value = value_node\r\n                            else\r\n                                return console.error_bb .. '<not found>[-]'\r\n                            end\r\n                        end\r\n                    end\r\n                    node[id] = value\r\n                    text = id .. ': ' .. console.value_bb .. tostring(value) .. '[-]'\r\n                end\r\n            end\r\n            return text\r\n        end\r\n    )\r\n\r\n    console.add_admin_command('exec', '['..console.option..'?qsv] <commands>',\r\n        'Execute a series of commands held in a string: commands are seperated by a new line or '..console.command_seperator,\r\n        function (player, ...)\r\n            local help_details = console.option..'q    quiet: will not output anything except final output\\n' ..\r\n                                 console.option..'s    silent: will not output anything at all\\n'..\r\n                                 console.option..'v    verbose: will output commands as they execute\\n'\r\n            local commands = nil\r\n            local verbose = false\r\n            local quiet = false\r\n            local silent = false\r\n            for _, arg in ipairs({...}) do\r\n                if type(arg) == 'string' and arg:len() > 1 and arg:sub(1,1) == console.option then\r\n                    local c = 2\r\n                    while c <= arg:len() do\r\n                        local option = arg:sub(c,c)\r\n                        if option == '?' then\r\n                            return help_details\r\n                        elseif option == 'q' then\r\n                            quiet = not quiet\r\n                        elseif option == 's' then\r\n                            silent = not silent\r\n                        elseif option == 'v' then\r\n                            verbose = not verbose\r\n                        else\r\n                            return console.error_bb .. \"<option '\" .. option .. \"' not recognized>\"\r\n                        end\r\n                        c = c + 1\r\n                    end\r\n                elseif commands == nil then\r\n                    commands = tostring(arg)\r\n                end\r\n            end\r\n            if silent then quiet = true end\r\n            if commands:len() > 1 and commands:sub(1, 1) == console.literal then\r\n                commands = commands:sub(2)\r\n            else\r\n                local variable = console.fill_path(commands)\r\n                local node, id, parent, found = console.node_from_path(variable)\r\n                if node ~= nil and found then\r\n                    commands = node\r\n                else\r\n                    return console.error_bb .. '<not found>[-]'\r\n                end\r\n            end\r\n            if commands:find('\\n') then\r\n                commands = console.split(commands, '\\n')\r\n            else\r\n                commands = console.split(commands, console.command_seperator)\r\n            end\r\n            local end_result = nil\r\n            for _, command_text in ipairs(commands) do\r\n                local command = ''\r\n                local command_function = nil\r\n                local parameters = {player}\r\n                local requires_admin = false\r\n                command, command_function, parameters, requires_admin = console.get_command(command_text, player)\r\n                if command ~= '' then\r\n                    if command_function and (player.admin or not requires_admin) then\r\n                        local response, mute = command_function(unpack(parameters))\r\n                        if response ~= nil or mute ~= nil then\r\n                            if not mute and verbose and not quiet then\r\n                                printToColor('\\n'..command_text, player.color, console.command_color)\r\n                            end\r\n                            if response then\r\n                                end_result = response\r\n                                if not quiet then\r\n                                    printToColor(response, player.color, console.output_color)\r\n                                end\r\n                            end\r\n                        end\r\n                    elseif not quiet then\r\n                        if verbose then printToColor('\\n'..command_text, player.color, console.command_color) end\r\n                        printToColor(console.error_bb .. \"<command '\" .. command .. \"' not found>[-]\", player.color, console.output_color)\r\n                    end\r\n                end\r\n            end\r\n            if end_result and not silent then\r\n                printToColor(end_result, player.color, console.output_color)\r\n            end\r\n        end\r\n    )\r\n\r\n    console.add_admin_command('watch', '['..console.option..'?cgp] ['..console.option..'t#] ['..console.option..console.seperator..'<property>] [<variable>]',\r\n        'Watch a variable or object and display it whenever it changes.\\n' .. console.hidden_bb ..\r\n        'Requires you to add a '..console.function_bb..'console.update()[-] call to an ' ..\r\n        console.function_bb .. 'onUpdate[-] event in your code.[-]\\n',\r\n        function (player, ...)\r\n            local help_details = 'Call without a parameter to display watched items, or with a variable to add it to watch list.\\n' ..\r\n                                console.option..'c will clear variable if specified, or all.\\n' ..\r\n                                console.option..'g will let you specify an object by its GUID.\\n' ..\r\n                                console.option..'t# will throttle output to # seconds.\\n' ..\r\n                                console.option..console.seperator..'<property> will watch the property of the variable.\\n' ..\r\n                                console.option..'p will pause or unpause watching.\\n'\r\n            local path = nil\r\n            local clearing = false\r\n            local throttle = nil\r\n            local pause_changed = false\r\n            local by_guid = false\r\n            local parameters = {}\r\n            local labels = {}\r\n            local property = nil\r\n            for _, arg in ipairs({...}) do\r\n                if type(arg) == 'string' and arg:len() > 1 and arg:sub(1,1) == console.option then\r\n                    local c = 2\r\n                    while c <= arg:len() do\r\n                        local option = arg:sub(c,c)\r\n                        if option == '?' then\r\n                            return help_details\r\n                        elseif option == 'c' then\r\n                            clearing = not clearing\r\n                        elseif option == 'p' then\r\n                            pause_changed = not pause_changed\r\n                        elseif option == 'g' then\r\n                            by_guid = not by_guid\r\n                        elseif option == console.seperator then\r\n                            if arg:len() > c then\r\n                                property = arg:sub(c + 1)\r\n                                c = arg:len() + 1\r\n                            end\r\n                        elseif option == 't' then\r\n                            local n = ''\r\n                            local j = c + 1\r\n                            while j <= arg:len() do\r\n                                local char = arg:sub(j, j)\r\n                                if char:match('[0-9.]') then\r\n                                    n = n .. char\r\n                                else\r\n                                    break\r\n                                end\r\n                                j = j + 1\r\n                            end\r\n                            c = j - 1\r\n                            if n == '' then\r\n                                return console.error_bb .. '<you must provide a throttle duration (in seconds)>[-]'\r\n                            else\r\n                                throttle = tonumber(n)\r\n                            end\r\n                        else\r\n                            return console.error_bb .. \"<option '\" .. option .. \"' not recognized>\"\r\n                        end\r\n                        c = c + 1\r\n                    end\r\n                else\r\n                    if path == nil then\r\n                        path = tostring(arg)\r\n                    else\r\n                        local label = tostring(arg)\r\n                        if type(arg) == 'string' then\r\n                            if arg:len() > 2 and arg:sub(1,1) == console.literal then\r\n                                arg = arg:sub(2)\r\n                                label = arg\r\n                            else\r\n                                local node, id, parent, found = console.node_from_path(console.fill_path(arg))\r\n                                if node ~= nil and found then\r\n                                    arg = node\r\n                                end\r\n                            end\r\n                        end\r\n                        table.insert(labels, label)\r\n                        table.insert(parameters, arg)\r\n                    end\r\n                end\r\n            end\r\n            local text = ''\r\n            if pause_changed then\r\n                if console.watch_list_paused then\r\n                    console.watch_list_paused = nil\r\n                    text = text .. console.header_bb .. '<unpaused>[-]'\r\n                else\r\n                    console.watch_list_paused = true\r\n                    text = text .. console.header_bb .. '<paused>[-]'\r\n                end\r\n            end\r\n            if path == nil then\r\n                if throttle ~= nil then\r\n                    text = text .. '\\n' .. console.error_bb .. '<you must provide a variable or object>[-]'\r\n                elseif by_guid then\r\n                    text = text .. '\\n' .. console.error_bb .. '<you must provide a GUID>[-]'\r\n                elseif clearing then\r\n                    console.watch_list = nil\r\n                    console.watch_list_paused = nil\r\n                    text = text .. '\\nWatch list cleared!'\r\n                elseif not pause_changed then\r\n                    if console.watch_list then\r\n                        local watched = {}\r\n                        for label, watch in pairs(console.watch_list) do\r\n                            if watch.player == player.color then\r\n                                table.insert(watched, label)\r\n                            end\r\n                        end\r\n                        table.sort(watched)\r\n                        text = text .. '\\n'..console.header_bb..'Watching:[-]'\r\n                        for _, label in ipairs(watched) do\r\n                            local watch = console.watch_list[label]\r\n                            local is_guid = (label:len() == 6 and label:sub(1,1) ~= console.seperator)\r\n                            local node, id, parent, found\r\n                            local prefix\r\n                            text = text .. '\\n'\r\n                            if is_guid then\r\n                                prefix =  console.format_guid(label)\r\n                                node = getObjectFromGUID(label)\r\n                                found = tostring(node) ~= 'null'\r\n                            else\r\n                                prefix = label\r\n                                node, id, parent, found = console.node_from_path(label)\r\n                            end\r\n                            if node ~= nil and found then\r\n                                if type(node) == 'userdata' then\r\n                                    prefix = console.object_bb .. prefix .. '[-]'\r\n                                    local position = node.getPosition()\r\n                                    local rotation = node.getRotation()\r\n                                    local p = function (x) return math.floor(x * 100) * 0.01 end\r\n                                    local r = function (x) return math.floor(x + 0.5) end\r\n                                    text = text .. prefix .. console.value_bb .. ' ∡ '..r(rotation.x)..' '..r(rotation.y)..' '..r(rotation.z) .. '[-]'..\r\n                                            console.boolean_bb..'   ⊞  '..p(position.x)..'   '..p(position.y)..'   '..p(position.z)\r\n                                elseif type(node) == 'function' then\r\n                                    local result = node(unpack(console.watch_list[label].parameters))\r\n                                    if watch.property and (type(result) == 'table' or type(result) == 'userdata') then\r\n                                        result = result[watch.property]\r\n                                        if type(result) == 'function' then\r\n                                            result = result()\r\n                                        end\r\n                                    end\r\n                                    result = tostring(result)\r\n                                    if watch.propery and watch.property:lower():find('guid') then\r\n                                        result = console.format_guid(result)\r\n                                    end\r\n                                    if result:len() > console.crop_string_at then result = result:sub(1, console.crop_string_at) .. '...' end\r\n                                    text = text .. watch.label .. console.value_bb .. result .. '[-]'\r\n                                else\r\n                                    if type(node) == 'boolean' then\r\n                                        if node then\r\n                                            node = 'true'\r\n                                        else\r\n                                            node = 'false'\r\n                                        end\r\n                                    elseif type(node) == 'string' then\r\n                                        if node:len() > console.crop_string_at then node = node:sub(1, console.crop_string_at):gsub('\\n', ' ') .. '...' end\r\n                                    end\r\n                                    text = text .. prefix .. ': ' .. console.value_bb .. node .. '[-]'\r\n                                end\r\n                            end\r\n                        end\r\n                    else\r\n                        text = text .. \"\\nWatch list is empty.\"\r\n                    end\r\n                end\r\n            else\r\n                if not by_guid then\r\n                    path = console.fill_path(path)\r\n                end\r\n                if clearing then\r\n                    local node, id, parent, found\r\n                    if not by_guid then\r\n                        node, id, parent, found, path = console.node_from_path(path)\r\n                    end\r\n                    if console.watch_list[path] then\r\n                        console.watch_list[path] = nil\r\n                        if next(console.watch_list) == nil then\r\n                            console.watch_list = nil\r\n                        end\r\n                        text = text .. '\\n' .. console.header_bb.. 'No longer watching:[-] ' .. path\r\n                    else\r\n                        text = text .. '\\n' .. console.error_bb .. '<not found>[-]'\r\n                    end\r\n                else\r\n                    local node, id, parent, found\r\n                    if by_guid then\r\n                        node = getObjectFromGUID(path)\r\n                        found = tostring(node) ~= 'null'\r\n                    else\r\n                        node, id, parent, found, path = console.node_from_path(path)\r\n                    end\r\n                    if node ~= nil and found then\r\n                        if console.watch_list == nil then console.watch_list = {} end\r\n                        if throttle == nil then throttle = 0 end\r\n                        console.watch_list[path] = {player=player.color, throttle=throttle, last_check=0, property=property}\r\n                        if type(node) == 'userdata' then\r\n                            console.watch_list[path].position = node.getPosition()\r\n                            console.watch_list[path].rotation = node.getRotation()\r\n                            console.watch_list[path].is_guid  = by_guid\r\n                        elseif type(node) == 'function' then\r\n                            console.watch_list[path].parameters = parameters\r\n                            console.watch_list[path].value = node\r\n                            console.watch_list[path].label = console.function_bb .. path .. '[-]'\r\n                            if property then\r\n                                console.watch_list[path].label = console.watch_list[path].label .. console.seperator .. property\r\n                            end\r\n                            for _, label in ipairs(labels) do\r\n                                console.watch_list[path].label = console.watch_list[path].label .. ' ' .. console.hidden_bb .. label .. '[-]'\r\n                            end\r\n                            console.watch_list[path].label = console.watch_list[path].label .. ': '\r\n                        else\r\n                            console.watch_list[path].value = node\r\n                        end\r\n                        if by_guid then\r\n                            path = console.format_guid(path)\r\n                        end\r\n                        text = text .. '\\n' .. console.header_bb .. 'Watching:[-] ' .. path\r\n                    else\r\n                        text = text .. '\\n' .. console.error_bb .. '<not found>[-]'\r\n                    end\r\n                end\r\n            end\r\n            if text:len() > 1 and text:sub(1, 1) == '\\n' then\r\n                text = text:sub(2)\r\n            end\r\n            return text\r\n        end\r\n    )\r\n\r\n    console.add_player_command('shout', '<text>',\r\n        'Broadcast <text> to all players. Colour a section with {RRGGBB}section{-}.',\r\n        function (player, ...)\r\n            local text = player.steam_name .. ': '\r\n            local space = ''\r\n            for _, word in ipairs({...}) do\r\n                text = text .. space .. tostring(word)\r\n                space = ' '\r\n            end\r\n            text = text:gsub('{','[')\r\n            text = text:gsub('}',']')\r\n            broadcastToAll(text, stringColorToRGB(player.color))\r\n            return nil, false\r\n        end\r\n    )\r\n\r\n    -- change the command help color so client added commands appear different to console++\r\n    console.set_command_listing_bb('[A0F0C0]')\r\nend\r\n\nend)\n__bundle_register(\"Console/console\", function(require, _LOADED, __bundle_register, __bundle_modules)\nif not console then\r\n    console = {}\r\n\r\n    -- Change these values as you wish\r\n    console.command_char = '>'\r\n    console.option       = '-'\r\n    console.prompt_color  = {r = 0.8,  g = 1.0,  b = 0.8 }\r\n    console.command_color = {r = 0.8,  g = 0.6,  b = 0.8 }\r\n    console.output_color  = {r = 0.88, g = 0.88, b = 0.88}\r\n    console.invalid_color = {r = 1.0,  g = 0.2,  b = 0.2 }\r\n    console.header_bb       = '[EECCAA]'\r\n    console.error_bb        = '[FF9999]'\r\n    console.inbuilt_help_bb = '[E0E0E0]'\r\n    console.client_help_bb  = '[C0C0FF]'\r\n\r\n    -- Exposed methods:\r\n\r\n    function console.add_validation_function(validation_function)\r\n        -- Adds a validation function all chat will be checked against:\r\n        -- function(string message) which returns (boolean valid, string response)\r\n        -- If all validation functions return <valid> as true the message will be displayed.\r\n        -- If one returns <valid> as false then its <response> will be displayed to that player instead.\r\n        table.insert(console.validation_functions, validation_function)\r\n    end\r\n\r\n    function console.add_player_command(command, parameter_text, help_text, command_function, default_parameters)\r\n        -- Adds a command anyone can use, see below for details\r\n        console.add_command(command, false, parameter_text, help_text, command_function, default_parameters)\r\n    end\r\n\r\n    function console.add_admin_command(command, parameter_text, help_text, command_function, default_parameters)\r\n        -- Adds a command only admins can use, see below for details\r\n        console.add_command(command, true, parameter_text, help_text, command_function, default_parameters)\r\n    end\r\n\r\n    function console.add_command(command, requires_admin, parameter_text, help_text, command_function, default_parameters)\r\n        -- Adds a command to the console.\r\n        -- command_function must take <player> as its first argument, and then any\r\n        --   subsequent arguments you wish which will be provided by the player.\r\n        -- You may alias an already-present command by calling this with command_function set to\r\n        --   the command string instead of a function.  default_parameters can be set for the alias.\r\n        -- See basic built-in commands at the bottom of this file for examples.\r\n        local commands = console.commands\r\n        local command_function = command_function\r\n        local help_text = help_text\r\n        local parameter_text = parameter_text\r\n        if type(command_function) == 'string' then --alias\r\n            if help_text == nil then\r\n                help_text = commands[command_function].help_text\r\n            end\r\n            if parameter_text == nil then\r\n                parameter_text = commands[command_function].parameter_text\r\n            end\r\n            command_function = commands[command_function].command_function\r\n        end\r\n        console.commands[command] = {\r\n            command_function   = command_function,\r\n            requires_admin     = requires_admin,\r\n            parameter_text     = parameter_text,\r\n            help_text          = help_text,\r\n            help_bb            = console.command_help_bb,\r\n            default_parameters = default_parameters,\r\n        }\r\n    end\r\n\r\n    function console.set_command_listing_bb(bb)\r\n        -- Tags commands added after with a bb color for when they are displayed (i.e. with 'help')\r\n        console.command_help_bb = bb\r\n    end\r\n\r\n    function console.disable()\r\n        -- Disables console for command purposes, but leaves validation functions running\r\n        console.active = false\r\n    end\r\n\r\n    function console.enable()\r\n        -- Enables console commands (console commands are on by default)\r\n        console.active = true\r\n    end\r\n\r\n    -- End of exposed methods.  You shouldn't need to interact with anything below (under normal circumstances)\r\n\r\n\r\n    console.active = true\r\n    console.in_command_mode = {}\r\n    console.commands = {}\r\n    console.validation_functions = {}\r\n    console.set_command_listing_bb(console.inbuilt_help_bb)\r\n\r\n    function onChat(message, player)\r\n        if message ~= '' then\r\n            local command = ''\r\n            local command_function = nil\r\n            local parameters = {player}\r\n            local requires_admin = false\r\n            local command_mode = console.in_command_mode[player.steam_id]\r\n            if command_mode and console.active then\r\n                command, command_function, parameters, requires_admin = console.get_command(message, player)\r\n            elseif message:sub(1, 1) == console.command_char and console.active then\r\n                if message:len() > 1 then\r\n                    command, command_function, parameters, requires_admin = console.get_command(message:sub(2), player)\r\n                else\r\n                    command, command_function, parameters, requires_admin = console.get_command(console.command_char, player)\r\n                end\r\n            else\r\n                for i, f in ipairs(console.validation_functions) do\r\n                    local valid, response = f(message)\r\n                    if response == nil then response = '' end\r\n                    if not valid then\r\n                        printToColor(response, player.color, console.invalid_color)\r\n                        return false\r\n                    end\r\n                end\r\n                return true\r\n            end\r\n            if console.active then\r\n                if command_function and (player.admin or not requires_admin) then\r\n                    if command_mode then\r\n                        message = console.command_char .. console.command_char .. message\r\n                    end\r\n                    local response, mute = command_function(unpack(parameters))\r\n                    if response ~= nil or mute ~= nil then\r\n                        if not mute then\r\n                            printToColor('\\n'..message, player.color, console.command_color)\r\n                        end\r\n                        if response then\r\n                            printToColor(response, player.color, console.output_color)\r\n                        end\r\n                    end\r\n                    if console.in_command_mode[player.steam_id] then console.display_prompt(player) end\r\n                    return false\r\n                else\r\n                    printToColor('\\n'..message, player.color, console.command_color)\r\n                    printToColor(console.error_bb .. \"<command '\" .. command .. \"' not found>[-]\", player.color, console.output_color)\r\n                    return false\r\n                end\r\n            end\r\n        end\r\n    end\r\n\r\n    function console.get_command(message, player)\r\n        local command_name = ''\r\n        local command_function = nil\r\n        local requires_admin = false\r\n        local parameters = {player}\r\n        for i, part in ipairs(console.split(message)) do\r\n            if i == 1 then\r\n                command_name = part\r\n                local command = console.commands[command_name]\r\n                if command then\r\n                    command_function = command.command_function\r\n                    requires_admin = command.requires_admin\r\n                    if command.default_parameters then\r\n                        for _, parameter in ipairs(command.default_parameters) do\r\n                            table.insert(parameters, parameter)\r\n                        end\r\n                    end\r\n                end\r\n            else\r\n                table.insert(parameters, part)\r\n            end\r\n        end\r\n        return command_name, command_function, parameters, requires_admin\r\n    end\r\n\r\n    function console.display_prompt(player)\r\n        printToColor(console.command_char..console.command_char, player.color, console.prompt_color)\r\n    end\r\n\r\n    function console.split(text, split_on)\r\n        local split_on = split_on or ' '\r\n        if type(split_on) == 'string' then\r\n            local s = {}\r\n            for c = 1, split_on:len() do\r\n                s[split_on:sub(c,c)] = true\r\n            end\r\n            split_on = s\r\n        end\r\n        local parts = {}\r\n        if text ~= '' then\r\n            local make_table = function(s)\r\n                local entries = console.split(s, ' ,')\r\n                local t = {}\r\n                for _, entry in ipairs(entries) do\r\n                    if type(entry) == 'string' and entry:find('=') then\r\n                        e = console.split(entry, '=')\r\n                        t[e[1]] = e[2]\r\n                    else\r\n                        table.insert(t, entry)\r\n                    end\r\n                end\r\n                return t\r\n            end\r\n            local current_split_on = split_on\r\n            local adding = false\r\n            local part = \"\"\r\n            local totype = tonumber\r\n            for c = 1, text:len() do\r\n                local char = text:sub(c, c)\r\n                if adding then\r\n                    if current_split_on[char] then -- ended current part\r\n                        if totype(part) ~= nil then\r\n                            table.insert(parts, totype(part))\r\n                        else\r\n                            table.insert(parts, part)\r\n                        end\r\n                        adding = false\r\n                        current_split_on = split_on\r\n                        totype = tonumber\r\n                    else\r\n                        part = part .. char\r\n                    end\r\n                else\r\n                    if not current_split_on[char] then -- found start of part\r\n                        if char == \"'\" then\r\n                            current_split_on = {[\"'\"] = true}\r\n                            totype = tostring\r\n                            part = ''\r\n                        elseif char == '\"' then\r\n                            current_split_on = {['\"'] = true}\r\n                            totype = tostring\r\n                            part = ''\r\n                        elseif char == '{' then\r\n                            current_split_on = {['}'] = true}\r\n                            totype = make_table\r\n                            part = ''\r\n                        else\r\n                            part = char\r\n                        end\r\n                        adding = true\r\n                    end\r\n                end\r\n            end\r\n            if adding then\r\n                if totype(part) ~= nil then\r\n                    table.insert(parts, totype(part))\r\n                else\r\n                    table.insert(parts, part)\r\n                end\r\n            end\r\n        end\r\n        return parts\r\n    end\r\n\r\n\r\n    -- Add basic built-in console commands\r\n\r\n    console.add_player_command('help', '[' .. console.option .. 'all|<command>]',\r\n        'Display available commands or help on all commands or help on a specific command.',\r\n        function (player, command)\r\n            if command ~= nil then\r\n                command = tostring(command)\r\n            end\r\n            local make_help = function (command)\r\n                return console.header_bb .. command .. ' ' .. console.commands[command].parameter_text ..\r\n                        '[-]\\n' .. console.commands[command].help_text\r\n            end\r\n            local info_mode = false\r\n            if command == console.option..'all' then\r\n                info_mode = true\r\n            end\r\n            if command and console.commands[command] then\r\n                return make_help(command)\r\n            elseif command and not info_mode then\r\n                return console.error_bb .. \"<command '\" .. command .. \"' not found>[-]\"\r\n            else\r\n                local msg = console.header_bb .. 'Available commands:[-]'\r\n                local command_list = {}\r\n                for c, _ in pairs(console.commands) do\r\n                    if player.admin or not console.commands[c].requires_admin then\r\n                        if info_mode then\r\n                            table.insert(command_list, make_help(c))\r\n                        else\r\n                            table.insert(command_list, c)\r\n                        end\r\n                    end\r\n                end\r\n                table.sort(command_list)\r\n                local sep\r\n                if info_mode then\r\n                    sep = '\\n\\n'\r\n                else\r\n                    sep = '\\n'\r\n                end\r\n                for _, c in ipairs(command_list) do\r\n                    local cmd = console.commands[c]\r\n                    if cmd then\r\n                        msg = msg .. sep .. cmd.help_bb .. c .. '[-]'\r\n                    else\r\n                        msg = msg .. sep .. c\r\n                    end\r\n                    if not info_mode then sep = ', ' end\r\n                end\r\n                return msg\r\n            end\r\n        end\r\n    )\r\n    console.add_player_command('?', nil, nil, 'help')\r\n    console.add_player_command('info', '', 'Display help on all available commands.', 'help', {console.option..'all'})\r\n\r\n    console.add_player_command('exit', '',\r\n        \"Leave <command mode> ('\" .. console.command_char .. \"' does the same).\",\r\n        function (player)\r\n            console.in_command_mode[player.steam_id] = nil\r\n            return console.header_bb .. '<command mode: off>[-]'\r\n        end\r\n    )\r\n\r\n    console.add_player_command('cmd', '',\r\n        \"Enter <command mode> ('\" .. console.command_char .. \"' does the same).\",\r\n        function (player)\r\n            console.in_command_mode[player.steam_id] = true\r\n            return console.header_bb .. '<command mode: on>[-]'\r\n        end\r\n    )\r\n\r\n    console.add_player_command(console.command_char, '',\r\n        'Toggle <command mode>',\r\n        function (player)\r\n            console.in_command_mode[player.steam_id] = not console.in_command_mode[player.steam_id]\r\n            if console.in_command_mode[player.steam_id] then\r\n                return console.header_bb .. '<command mode: on>[-]', true\r\n            else\r\n                return console.header_bb .. '<command mode: off>[-]', true\r\n            end\r\n        end\r\n    )\r\n\r\n    console.add_player_command('=', '<expression>',\r\n        'Evaluate an expression',\r\n        function (player, ...)\r\n            local expression = ''\r\n            for _, arg in ipairs({...}) do\r\n                expression = expression .. ' ' .. tostring(arg)\r\n            end\r\n            if not player.admin then\r\n                expression = expression:gasub('[a-zA-Z~]', '')\r\n            end\r\n            console.returned_value = dynamic.eval(expression)\r\n            return console.returned_value\r\n        end\r\n    )\r\n\r\n    console.add_player_command('echo', '<text>',\r\n        'Display text on screen',\r\n        function (player, ...)\r\n            local text = ''\r\n            for _, arg in ipairs({...}) do\r\n                text = text .. ' ' .. tostring(arg)\r\n            end\r\n            printToColor(text, player.color, console.output_color)\r\n            return false\r\n        end\r\n    )\r\n\r\n    console.add_player_command('cls', '',\r\n        'Clear console text',\r\n        function (player)\r\n            return '\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n' ..\r\n                   '\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n'\r\n        end\r\n    )\r\n\r\n    console.add_player_command('alias', '<alias> <command> [<parameter>...]',\r\n        'Create a command alias.',\r\n        function (player, ...)\r\n            local alias\r\n            local command\r\n            local parameters = {}\r\n            for i, arg in ipairs({...}) do\r\n                if i == 1 then\r\n                    alias = tostring(arg)\r\n                elseif i == 2 then\r\n                    command = tostring(arg)\r\n                else\r\n                    table.insert(parameters, arg)\r\n                end\r\n            end\r\n            if not alias then\r\n                return console.error_bb .. '<must provide an alias>[-]'\r\n            --elseif console.commands[alias] ~= nil then\r\n            --    return console.error_bb .. \"<command '\" .. alias .. \"' already exists!>[-]\"\r\n            elseif command == nil then\r\n                return console.error_bb .. \"<must provide a command>[-]\"\r\n            elseif console.commands[command] == nil then\r\n                return console.error_bb .. \"<command '\" .. command .. \"' does not exist>[-]\"\r\n            else\r\n                local text = console.header_bb .. alias .. '[-] = ' .. command\r\n                local help_text = console.commands[command].help_text\r\n                if not help_text:find('\\nAliased to: ') then\r\n                    help_text = help_text .. '\\nAliased to: ' .. command\r\n                end\r\n                local combined_parameters = {}\r\n                if console.commands[command].default_parameters then\r\n                    for _, parameter in ipairs(console.commands[command].default_parameters) do\r\n                        table.insert(combined_parameters, parameter)\r\n                    end\r\n                end\r\n                for _, parameter in ipairs(parameters) do\r\n                    table.insert(combined_parameters, parameter)\r\n                    text = text .. ' ' .. parameter\r\n                    help_text = help_text .. ' ' .. parameter\r\n                end\r\n                console.add_command(alias, console.commands[command].requires_admin, console.commands[command].parameter_text, help_text, command, combined_parameters)\r\n                return text\r\n            end\r\n        end\r\n    )\r\n\r\n    -- change the command help color so client added commands appear different to in-built\r\n    console.set_command_listing_bb(console.client_help_bb)\r\nend\r\n\nend)\nreturn __bundle_require(\"Global.-1.lua\")",
   "LuaScriptState": "",
   "XmlUI": "<!-- Xml UI. See documentation: https://api.tabletopsimulator.com/ui/introUI/ -->",
   "SnapPoints": [
@@ -318,6 +318,1878 @@
   ],
   "ObjectStates": [
     {
+      "GUID": "0828d5",
+      "Name": "3DText",
+      "Transform": {
+        "posX": -2.85000134,
+        "posY": 1.34999645,
+        "posZ": -8.150007,
+        "rotX": 90.0,
+        "rotY": 0.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "5b6d71",
+      "Name": "3DText",
+      "Transform": {
+        "posX": -4.15000248,
+        "posY": 1.34999657,
+        "posZ": -8.150007,
+        "rotX": 90.0,
+        "rotY": 0.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "537c95",
+      "Name": "3DText",
+      "Transform": {
+        "posX": -5.480003,
+        "posY": 1.34999669,
+        "posZ": -8.150007,
+        "rotX": 90.0,
+        "rotY": 0.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "4b7355",
+      "Name": "ScriptingTrigger",
+      "Transform": {
+        "posX": 1.31,
+        "posY": 3.84,
+        "posZ": -14.33,
+        "rotX": 0.0,
+        "rotY": 0.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 5.1,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0,
+        "a": 0.509803951
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "a29fbf",
+      "Name": "3DText",
+      "Transform": {
+        "posX": 12.17001,
+        "posY": 1.34999716,
+        "posZ": -8.150003,
+        "rotX": 90.0,
+        "rotY": 0.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "b40d10",
+      "Name": "3DText",
+      "Transform": {
+        "posX": 10.8400059,
+        "posY": 1.34999716,
+        "posZ": -8.150003,
+        "rotX": 90.0,
+        "rotY": 0.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "20dbde",
+      "Name": "3DText",
+      "Transform": {
+        "posX": 9.510005,
+        "posY": 1.34999728,
+        "posZ": -8.150007,
+        "rotX": 90.0,
+        "rotY": 0.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "d3086e",
+      "Name": "ScriptingTrigger",
+      "Transform": {
+        "posX": 16.35,
+        "posY": 3.84,
+        "posZ": -14.33,
+        "rotX": 0.0,
+        "rotY": 0.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 5.1,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0,
+        "a": 0.509803951
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "6039cf",
+      "Name": "3DText",
+      "Transform": {
+        "posX": -13.2000084,
+        "posY": 1.34999824,
+        "posZ": 3.12999845,
+        "rotX": 90.0,
+        "rotY": 90.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "45c898",
+      "Name": "3DText",
+      "Transform": {
+        "posX": -13.2000084,
+        "posY": 1.34999824,
+        "posZ": 4.459998,
+        "rotX": 90.0,
+        "rotY": 90.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "a2f853",
+      "Name": "3DText",
+      "Transform": {
+        "posX": -13.2000084,
+        "posY": 1.34999824,
+        "posZ": 5.78999853,
+        "rotX": 90.0,
+        "rotY": 90.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "f5c967",
+      "Name": "ScriptingTrigger",
+      "Transform": {
+        "posX": -19.36,
+        "posY": 3.84,
+        "posZ": -0.95,
+        "rotX": 0.0,
+        "rotY": 0.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 5.1,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0,
+        "a": 0.509803951
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "15ad99",
+      "Name": "3DText",
+      "Transform": {
+        "posX": -2.85000277,
+        "posY": 1.35000014,
+        "posZ": -8.150014,
+        "rotX": 90.0,
+        "rotY": 1.15148364E-12,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "6b6519",
+      "Name": "3DText",
+      "Transform": {
+        "posX": -4.15000534,
+        "posY": 1.35000026,
+        "posZ": -8.150014,
+        "rotX": 90.0,
+        "rotY": 1.15148364E-12,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "668a13",
+      "Name": "3DText",
+      "Transform": {
+        "posX": -5.48000574,
+        "posY": 1.34999859,
+        "posZ": -8.150014,
+        "rotX": 90.0,
+        "rotY": 1.15148364E-12,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "7358df",
+      "Name": "ScriptingTrigger",
+      "Transform": {
+        "posX": 1.31,
+        "posY": 3.84,
+        "posZ": -14.33,
+        "rotX": 0.0,
+        "rotY": 0.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 5.1,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0,
+        "a": 0.509803951
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "f66136",
+      "Name": "3DText",
+      "Transform": {
+        "posX": 12.1700182,
+        "posY": 1.34999907,
+        "posZ": -8.150008,
+        "rotX": 90.0,
+        "rotY": 1.15148364E-12,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "91728f",
+      "Name": "3DText",
+      "Transform": {
+        "posX": 10.8400106,
+        "posY": 1.34999907,
+        "posZ": -8.15001,
+        "rotX": 90.0,
+        "rotY": 1.15148364E-12,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "29e3d5",
+      "Name": "3DText",
+      "Transform": {
+        "posX": 9.51001,
+        "posY": 1.34999919,
+        "posZ": -8.15001,
+        "rotX": 90.0,
+        "rotY": 1.15148364E-12,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "5538e0",
+      "Name": "ScriptingTrigger",
+      "Transform": {
+        "posX": 16.35,
+        "posY": 3.84,
+        "posZ": -14.33,
+        "rotX": 0.0,
+        "rotY": 0.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 5.1,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0,
+        "a": 0.509803951
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "5827da",
+      "Name": "3DText",
+      "Transform": {
+        "posX": -13.2000179,
+        "posY": 1.35000014,
+        "posZ": 3.12999535,
+        "rotX": 90.0,
+        "rotY": 90.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "371b89",
+      "Name": "3DText",
+      "Transform": {
+        "posX": -13.2000179,
+        "posY": 1.35000014,
+        "posZ": 4.459996,
+        "rotX": 90.0,
+        "rotY": 90.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "b9f25c",
+      "Name": "3DText",
+      "Transform": {
+        "posX": -13.2000179,
+        "posY": 1.35000014,
+        "posZ": 5.789995,
+        "rotX": 90.0,
+        "rotY": 90.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "bbb891",
+      "Name": "ScriptingTrigger",
+      "Transform": {
+        "posX": -19.36,
+        "posY": 3.84,
+        "posZ": -0.95,
+        "rotX": 0.0,
+        "rotY": 0.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 5.1,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0,
+        "a": 0.509803951
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "12e10a",
+      "Name": "3DText",
+      "Transform": {
+        "posX": -2.850004,
+        "posY": 1.34999645,
+        "posZ": -8.150018,
+        "rotX": 90.0,
+        "rotY": 1.15148364E-12,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "21b1af",
+      "Name": "3DText",
+      "Transform": {
+        "posX": -4.15000772,
+        "posY": 1.34999657,
+        "posZ": -8.150018,
+        "rotX": 90.0,
+        "rotY": 1.15148364E-12,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "2a143f",
+      "Name": "3DText",
+      "Transform": {
+        "posX": -5.480008,
+        "posY": 1.34999669,
+        "posZ": -8.150018,
+        "rotX": 90.0,
+        "rotY": 1.15148364E-12,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "658093",
+      "Name": "ScriptingTrigger",
+      "Transform": {
+        "posX": 1.31,
+        "posY": 3.84,
+        "posZ": -14.33,
+        "rotX": 0.0,
+        "rotY": 0.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 5.1,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0,
+        "a": 0.509803951
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "861729",
+      "Name": "3DText",
+      "Transform": {
+        "posX": 12.1700287,
+        "posY": 1.34999716,
+        "posZ": -8.150016,
+        "rotX": 90.0,
+        "rotY": 1.15148364E-12,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "e3061e",
+      "Name": "3DText",
+      "Transform": {
+        "posX": 10.8400135,
+        "posY": 1.34999716,
+        "posZ": -8.150018,
+        "rotX": 90.0,
+        "rotY": 1.15148364E-12,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "f3ddb9",
+      "Name": "3DText",
+      "Transform": {
+        "posX": 9.51001549,
+        "posY": 1.34999526,
+        "posZ": -8.15002,
+        "rotX": 90.0,
+        "rotY": 1.15148364E-12,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "127013",
+      "Name": "ScriptingTrigger",
+      "Transform": {
+        "posX": 16.35,
+        "posY": 3.84,
+        "posZ": -14.33,
+        "rotX": 0.0,
+        "rotY": 0.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 5.1,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0,
+        "a": 0.509803951
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "c4283f",
+      "Name": "3DText",
+      "Transform": {
+        "posX": -13.2000265,
+        "posY": 1.34999824,
+        "posZ": 3.12999535,
+        "rotX": 90.0,
+        "rotY": 90.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "daa919",
+      "Name": "3DText",
+      "Transform": {
+        "posX": -13.2000265,
+        "posY": 1.34999824,
+        "posZ": 4.459995,
+        "rotX": 90.0,
+        "rotY": 90.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "f1ef69",
+      "Name": "3DText",
+      "Transform": {
+        "posX": -13.2000265,
+        "posY": 1.34999824,
+        "posZ": 5.789995,
+        "rotX": 90.0,
+        "rotY": 90.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 1.0,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "Text": {
+        "Text": "0",
+        "colorstate": {
+          "r": 1.0,
+          "g": 1.0,
+          "b": 1.0
+        },
+        "fontSize": 64
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
+      "GUID": "87fa5b",
+      "Name": "ScriptingTrigger",
+      "Transform": {
+        "posX": -19.36,
+        "posY": 3.84,
+        "posZ": -0.95,
+        "rotX": 0.0,
+        "rotY": 0.0,
+        "rotZ": 0.0,
+        "scaleX": 1.0,
+        "scaleY": 5.1,
+        "scaleZ": 1.0
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0,
+        "a": 0.509803951
+      },
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": ""
+    },
+    {
       "GUID": "bb9483",
       "Name": "Custom_Board",
       "Transform": {
@@ -346,262 +2218,6 @@
       },
       "Tags": [
         "Red"
-      ],
-      "LayoutGroupSortIndex": 0,
-      "Value": 0,
-      "Locked": true,
-      "Grid": true,
-      "Snap": true,
-      "IgnoreFoW": false,
-      "MeasureMovement": false,
-      "DragSelectable": true,
-      "Autoraise": true,
-      "Sticky": true,
-      "Tooltip": true,
-      "GridProjection": false,
-      "HideWhenFaceDown": false,
-      "Hands": false,
-      "CustomImage": {
-        "ImageURL": "http://cloud-3.steamusercontent.com/ugc/2057633340020313087/952D9E0B153AE35473DA1E5E4485C19CC13A7F9B/",
-        "ImageSecondaryURL": "",
-        "ImageScalar": 1.0,
-        "WidthScale": 1.44722223
-      },
-      "LuaScript": "",
-      "LuaScriptState": "",
-      "XmlUI": "",
-      "AttachedSnapPoints": [
-        {
-          "Position": {
-            "x": -1.70487273,
-            "y": 0.5922457,
-            "z": 4.65217447
-          },
-          "Rotation": {
-            "x": -6.99083E-07,
-            "y": 359.978882,
-            "z": 180.0
-          }
-        },
-        {
-          "Position": {
-            "x": 6.421097,
-            "y": 0.5922457,
-            "z": 4.73291874
-          },
-          "Rotation": {
-            "x": 1.98304019E-06,
-            "y": 359.978638,
-            "z": 180.0
-          }
-        },
-        {
-          "Position": {
-            "x": 2.427551,
-            "y": 0.592245936,
-            "z": 4.69387674
-          },
-          "Rotation": {
-            "x": 1.2821698E-05,
-            "y": 359.947662,
-            "z": -1.25307025E-07
-          }
-        },
-        {
-          "Position": {
-            "x": -6.498179,
-            "y": 0.5922418,
-            "z": 4.631107
-          },
-          "Rotation": {
-            "x": 6.41762063E-06,
-            "y": 359.9787,
-            "z": 4.43342827E-07
-          }
-        },
-        {
-          "Position": {
-            "x": -6.482119,
-            "y": 0.5922434,
-            "z": -4.484806
-          },
-          "Rotation": {
-            "x": 7.945485E-06,
-            "y": 359.9787,
-            "z": -1.21888519E-07
-          }
-        },
-        {
-          "Position": {
-            "x": -1.75949085,
-            "y": 0.592245162,
-            "z": -4.44758368
-          },
-          "Rotation": {
-            "x": 3.21791845E-06,
-            "y": 359.979279,
-            "z": 180.0
-          }
-        }
-      ]
-    },
-    {
-      "GUID": "a26536",
-      "Name": "Custom_Board",
-      "Transform": {
-        "posX": -15.0,
-        "posY": 0.9820624,
-        "posZ": 12.999999,
-        "rotX": -2.24769374E-05,
-        "rotY": 359.978516,
-        "rotZ": 1.58932181E-07,
-        "scaleX": 0.375000447,
-        "scaleY": 0.375000447,
-        "scaleZ": 0.375000447
-      },
-      "Nickname": "",
-      "Description": "",
-      "GMNotes": "",
-      "AltLookAngle": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-      },
-      "ColorDiffuse": {
-        "r": 0.7867647,
-        "g": 0.7867647,
-        "b": 0.7867647
-      },
-      "Tags": [
-        "Green"
-      ],
-      "LayoutGroupSortIndex": 0,
-      "Value": 0,
-      "Locked": true,
-      "Grid": true,
-      "Snap": true,
-      "IgnoreFoW": false,
-      "MeasureMovement": false,
-      "DragSelectable": true,
-      "Autoraise": true,
-      "Sticky": true,
-      "Tooltip": true,
-      "GridProjection": false,
-      "HideWhenFaceDown": false,
-      "Hands": false,
-      "CustomImage": {
-        "ImageURL": "http://cloud-3.steamusercontent.com/ugc/2057633340020313087/952D9E0B153AE35473DA1E5E4485C19CC13A7F9B/",
-        "ImageSecondaryURL": "",
-        "ImageScalar": 1.0,
-        "WidthScale": 1.44722223
-      },
-      "LuaScript": "",
-      "LuaScriptState": "",
-      "XmlUI": "",
-      "AttachedSnapPoints": [
-        {
-          "Position": {
-            "x": -1.70487273,
-            "y": 0.5922457,
-            "z": 4.65217447
-          },
-          "Rotation": {
-            "x": -6.99083046E-07,
-            "y": 359.978882,
-            "z": 180.0
-          }
-        },
-        {
-          "Position": {
-            "x": 6.421097,
-            "y": 0.5922457,
-            "z": 4.73291874
-          },
-          "Rotation": {
-            "x": 1.98304019E-06,
-            "y": 359.978638,
-            "z": 180.0
-          }
-        },
-        {
-          "Position": {
-            "x": 2.427551,
-            "y": 0.592245936,
-            "z": 4.69387674
-          },
-          "Rotation": {
-            "x": 1.28216989E-05,
-            "y": 359.947662,
-            "z": -1.25307025E-07
-          }
-        },
-        {
-          "Position": {
-            "x": -6.498179,
-            "y": 0.5922418,
-            "z": 4.631107
-          },
-          "Rotation": {
-            "x": 6.417621E-06,
-            "y": 359.9787,
-            "z": 4.43342827E-07
-          }
-        },
-        {
-          "Position": {
-            "x": -6.482119,
-            "y": 0.5922434,
-            "z": -4.484806
-          },
-          "Rotation": {
-            "x": 7.945485E-06,
-            "y": 359.9787,
-            "z": -1.21888519E-07
-          }
-        },
-        {
-          "Position": {
-            "x": -1.75949085,
-            "y": 0.592245162,
-            "z": -4.44758368
-          },
-          "Rotation": {
-            "x": 3.21791845E-06,
-            "y": 359.979279,
-            "z": 180.0
-          }
-        }
-      ]
-    },
-    {
-      "GUID": "e9e844",
-      "Name": "Custom_Board",
-      "Transform": {
-        "posX": 14.9996271,
-        "posY": 0.9820637,
-        "posZ": 12.994194,
-        "rotX": 4.028061E-06,
-        "rotY": 0.03271997,
-        "rotZ": -5.54930928E-08,
-        "scaleX": 0.375000447,
-        "scaleY": 0.375000447,
-        "scaleZ": 0.375000447
-      },
-      "Nickname": "",
-      "Description": "",
-      "GMNotes": "",
-      "AltLookAngle": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-      },
-      "ColorDiffuse": {
-        "r": 0.7867647,
-        "g": 0.7867647,
-        "b": 0.7867647
-      },
-      "Tags": [
-        "Blue"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -702,15 +2318,15 @@
       ]
     },
     {
-      "GUID": "2a84df",
+      "GUID": "a26536",
       "Name": "Custom_Board",
       "Transform": {
-        "posX": 14.999999,
-        "posY": 0.9820629,
-        "posZ": -12.0,
-        "rotX": 2.53938083E-06,
-        "rotY": 179.9661,
-        "rotZ": 1.6444821E-07,
+        "posX": -15.0,
+        "posY": 0.9820624,
+        "posZ": 12.999999,
+        "rotX": -2.24769374E-05,
+        "rotY": 359.978516,
+        "rotZ": 1.58932181E-07,
         "scaleX": 0.375000447,
         "scaleY": 0.375000447,
         "scaleZ": 0.375000447
@@ -729,7 +2345,7 @@
         "b": 0.7867647
       },
       "Tags": [
-        "Pink"
+        "Green"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -830,15 +2446,15 @@
       ]
     },
     {
-      "GUID": "562e8e",
+      "GUID": "e9e844",
       "Name": "Custom_Board",
       "Transform": {
-        "posX": 1.02412116E-07,
-        "posY": 0.982062757,
-        "posZ": -12.000001,
-        "rotX": -2.52931318E-06,
-        "rotY": 179.9746,
-        "rotZ": 1.60345522E-07,
+        "posX": 14.9996271,
+        "posY": 0.9820637,
+        "posZ": 12.994194,
+        "rotX": 4.028061E-06,
+        "rotY": 0.03271997,
+        "rotZ": -5.54930537E-08,
         "scaleX": 0.375000447,
         "scaleY": 0.375000447,
         "scaleZ": 0.375000447
@@ -857,263 +2473,7 @@
         "b": 0.7867647
       },
       "Tags": [
-        "White"
-      ],
-      "LayoutGroupSortIndex": 0,
-      "Value": 0,
-      "Locked": true,
-      "Grid": true,
-      "Snap": true,
-      "IgnoreFoW": false,
-      "MeasureMovement": false,
-      "DragSelectable": true,
-      "Autoraise": true,
-      "Sticky": true,
-      "Tooltip": true,
-      "GridProjection": false,
-      "HideWhenFaceDown": false,
-      "Hands": false,
-      "CustomImage": {
-        "ImageURL": "http://cloud-3.steamusercontent.com/ugc/2057633340020313087/952D9E0B153AE35473DA1E5E4485C19CC13A7F9B/",
-        "ImageSecondaryURL": "",
-        "ImageScalar": 1.0,
-        "WidthScale": 1.44722223
-      },
-      "LuaScript": "",
-      "LuaScriptState": "",
-      "XmlUI": "",
-      "AttachedSnapPoints": [
-        {
-          "Position": {
-            "x": -1.70487273,
-            "y": 0.5922457,
-            "z": 4.65217447
-          },
-          "Rotation": {
-            "x": -6.990831E-07,
-            "y": 359.978882,
-            "z": 180.0
-          }
-        },
-        {
-          "Position": {
-            "x": 6.421097,
-            "y": 0.5922457,
-            "z": 4.73291874
-          },
-          "Rotation": {
-            "x": 1.98304019E-06,
-            "y": 359.978638,
-            "z": 180.0
-          }
-        },
-        {
-          "Position": {
-            "x": 2.427551,
-            "y": 0.592245936,
-            "z": 4.69387674
-          },
-          "Rotation": {
-            "x": 1.28217E-05,
-            "y": 359.947662,
-            "z": -1.25307025E-07
-          }
-        },
-        {
-          "Position": {
-            "x": -6.498179,
-            "y": 0.5922418,
-            "z": 4.631107
-          },
-          "Rotation": {
-            "x": 6.41762153E-06,
-            "y": 359.9787,
-            "z": 4.43342827E-07
-          }
-        },
-        {
-          "Position": {
-            "x": -6.482119,
-            "y": 0.5922434,
-            "z": -4.484806
-          },
-          "Rotation": {
-            "x": 7.945485E-06,
-            "y": 359.9787,
-            "z": -1.21888519E-07
-          }
-        },
-        {
-          "Position": {
-            "x": -1.75949085,
-            "y": 0.592245162,
-            "z": -4.44758368
-          },
-          "Rotation": {
-            "x": 3.21791845E-06,
-            "y": 359.979279,
-            "z": 180.0
-          }
-        }
-      ]
-    },
-    {
-      "GUID": "a442be",
-      "Name": "Custom_Board",
-      "Transform": {
-        "posX": 17.07407,
-        "posY": 0.982061744,
-        "posZ": 0.511031866,
-        "rotX": -4.542765E-06,
-        "rotY": 90.02085,
-        "rotZ": -1.41595569E-06,
-        "scaleX": 0.375000447,
-        "scaleY": 0.375000447,
-        "scaleZ": 0.375000447
-      },
-      "Nickname": "",
-      "Description": "",
-      "GMNotes": "",
-      "AltLookAngle": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-      },
-      "ColorDiffuse": {
-        "r": 0.7867647,
-        "g": 0.7867647,
-        "b": 0.7867647
-      },
-      "Tags": [
-        "Purple"
-      ],
-      "LayoutGroupSortIndex": 0,
-      "Value": 0,
-      "Locked": true,
-      "Grid": true,
-      "Snap": true,
-      "IgnoreFoW": false,
-      "MeasureMovement": false,
-      "DragSelectable": true,
-      "Autoraise": true,
-      "Sticky": true,
-      "Tooltip": true,
-      "GridProjection": false,
-      "HideWhenFaceDown": false,
-      "Hands": false,
-      "CustomImage": {
-        "ImageURL": "http://cloud-3.steamusercontent.com/ugc/2057633340020313087/952D9E0B153AE35473DA1E5E4485C19CC13A7F9B/",
-        "ImageSecondaryURL": "",
-        "ImageScalar": 1.0,
-        "WidthScale": 1.44722223
-      },
-      "LuaScript": "",
-      "LuaScriptState": "",
-      "XmlUI": "",
-      "AttachedSnapPoints": [
-        {
-          "Position": {
-            "x": -1.70487273,
-            "y": 0.5922457,
-            "z": 4.65217447
-          },
-          "Rotation": {
-            "x": -6.990833E-07,
-            "y": 359.978882,
-            "z": 180.0
-          }
-        },
-        {
-          "Position": {
-            "x": 6.421097,
-            "y": 0.5922457,
-            "z": 4.73291874
-          },
-          "Rotation": {
-            "x": 1.98304019E-06,
-            "y": 359.978638,
-            "z": 180.0
-          }
-        },
-        {
-          "Position": {
-            "x": 2.427551,
-            "y": 0.592245936,
-            "z": 4.69387674
-          },
-          "Rotation": {
-            "x": 1.28217025E-05,
-            "y": 359.947662,
-            "z": -1.25307025E-07
-          }
-        },
-        {
-          "Position": {
-            "x": -6.498179,
-            "y": 0.5922418,
-            "z": 4.631107
-          },
-          "Rotation": {
-            "x": 6.417623E-06,
-            "y": 359.9787,
-            "z": 4.43342827E-07
-          }
-        },
-        {
-          "Position": {
-            "x": -6.482119,
-            "y": 0.5922434,
-            "z": -4.484806
-          },
-          "Rotation": {
-            "x": 7.945485E-06,
-            "y": 359.9787,
-            "z": -1.21888519E-07
-          }
-        },
-        {
-          "Position": {
-            "x": -1.75949085,
-            "y": 0.592245162,
-            "z": -4.44758368
-          },
-          "Rotation": {
-            "x": 3.21791845E-06,
-            "y": 359.979279,
-            "z": 180.0
-          }
-        }
-      ]
-    },
-    {
-      "GUID": "2ef9b7",
-      "Name": "Custom_Board",
-      "Transform": {
-        "posX": -16.999176,
-        "posY": 0.982063,
-        "posZ": 0.318844736,
-        "rotX": -9.692084E-06,
-        "rotY": 270.0193,
-        "rotZ": 9.045617E-06,
-        "scaleX": 0.375000447,
-        "scaleY": 0.375000447,
-        "scaleZ": 0.375000447
-      },
-      "Nickname": "",
-      "Description": "",
-      "GMNotes": "",
-      "AltLookAngle": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-      },
-      "ColorDiffuse": {
-        "r": 0.7867647,
-        "g": 0.7867647,
-        "b": 0.7867647
-      },
-      "Tags": [
-        "Yellow"
+        "Blue"
       ],
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -1214,6 +2574,518 @@
       ]
     },
     {
+      "GUID": "2a84df",
+      "Name": "Custom_Board",
+      "Transform": {
+        "posX": 14.999999,
+        "posY": 0.9820629,
+        "posZ": -12.0,
+        "rotX": 2.53938083E-06,
+        "rotY": 179.9661,
+        "rotZ": 1.6444821E-07,
+        "scaleX": 0.375000447,
+        "scaleY": 0.375000447,
+        "scaleZ": 0.375000447
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 0.7867647,
+        "g": 0.7867647,
+        "b": 0.7867647
+      },
+      "Tags": [
+        "Pink"
+      ],
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "CustomImage": {
+        "ImageURL": "http://cloud-3.steamusercontent.com/ugc/2057633340020313087/952D9E0B153AE35473DA1E5E4485C19CC13A7F9B/",
+        "ImageSecondaryURL": "",
+        "ImageScalar": 1.0,
+        "WidthScale": 1.44722223
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": "",
+      "AttachedSnapPoints": [
+        {
+          "Position": {
+            "x": -1.70487273,
+            "y": 0.5922457,
+            "z": 4.65217447
+          },
+          "Rotation": {
+            "x": -6.990834E-07,
+            "y": 359.978882,
+            "z": 180.0
+          }
+        },
+        {
+          "Position": {
+            "x": 6.421097,
+            "y": 0.5922457,
+            "z": 4.73291874
+          },
+          "Rotation": {
+            "x": 1.98304019E-06,
+            "y": 359.978638,
+            "z": 180.0
+          }
+        },
+        {
+          "Position": {
+            "x": 2.427551,
+            "y": 0.592245936,
+            "z": 4.69387674
+          },
+          "Rotation": {
+            "x": 1.28217043E-05,
+            "y": 359.947662,
+            "z": -1.25307025E-07
+          }
+        },
+        {
+          "Position": {
+            "x": -6.498179,
+            "y": 0.5922418,
+            "z": 4.631107
+          },
+          "Rotation": {
+            "x": 6.417624E-06,
+            "y": 359.9787,
+            "z": 4.43342827E-07
+          }
+        },
+        {
+          "Position": {
+            "x": -6.482119,
+            "y": 0.5922434,
+            "z": -4.484806
+          },
+          "Rotation": {
+            "x": 7.945485E-06,
+            "y": 359.9787,
+            "z": -1.21888519E-07
+          }
+        },
+        {
+          "Position": {
+            "x": -1.75949085,
+            "y": 0.592245162,
+            "z": -4.44758368
+          },
+          "Rotation": {
+            "x": 3.21791845E-06,
+            "y": 359.979279,
+            "z": 180.0
+          }
+        }
+      ]
+    },
+    {
+      "GUID": "562e8e",
+      "Name": "Custom_Board",
+      "Transform": {
+        "posX": 1.02412116E-07,
+        "posY": 0.982062757,
+        "posZ": -12.000001,
+        "rotX": -2.52931318E-06,
+        "rotY": 179.9746,
+        "rotZ": 1.60345522E-07,
+        "scaleX": 0.375000447,
+        "scaleY": 0.375000447,
+        "scaleZ": 0.375000447
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 0.7867647,
+        "g": 0.7867647,
+        "b": 0.7867647
+      },
+      "Tags": [
+        "White"
+      ],
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "CustomImage": {
+        "ImageURL": "http://cloud-3.steamusercontent.com/ugc/2057633340020313087/952D9E0B153AE35473DA1E5E4485C19CC13A7F9B/",
+        "ImageSecondaryURL": "",
+        "ImageScalar": 1.0,
+        "WidthScale": 1.44722223
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": "",
+      "AttachedSnapPoints": [
+        {
+          "Position": {
+            "x": -1.70487273,
+            "y": 0.5922457,
+            "z": 4.65217447
+          },
+          "Rotation": {
+            "x": -6.990833E-07,
+            "y": 359.978882,
+            "z": 180.0
+          }
+        },
+        {
+          "Position": {
+            "x": 6.421097,
+            "y": 0.5922457,
+            "z": 4.73291874
+          },
+          "Rotation": {
+            "x": 1.98304019E-06,
+            "y": 359.978638,
+            "z": 180.0
+          }
+        },
+        {
+          "Position": {
+            "x": 2.427551,
+            "y": 0.592245936,
+            "z": 4.69387674
+          },
+          "Rotation": {
+            "x": 1.28217025E-05,
+            "y": 359.947662,
+            "z": -1.25307025E-07
+          }
+        },
+        {
+          "Position": {
+            "x": -6.498179,
+            "y": 0.5922418,
+            "z": 4.631107
+          },
+          "Rotation": {
+            "x": 6.417623E-06,
+            "y": 359.9787,
+            "z": 4.43342827E-07
+          }
+        },
+        {
+          "Position": {
+            "x": -6.482119,
+            "y": 0.5922434,
+            "z": -4.484806
+          },
+          "Rotation": {
+            "x": 7.945485E-06,
+            "y": 359.9787,
+            "z": -1.21888519E-07
+          }
+        },
+        {
+          "Position": {
+            "x": -1.75949085,
+            "y": 0.592245162,
+            "z": -4.44758368
+          },
+          "Rotation": {
+            "x": 3.21791845E-06,
+            "y": 359.979279,
+            "z": 180.0
+          }
+        }
+      ]
+    },
+    {
+      "GUID": "a442be",
+      "Name": "Custom_Board",
+      "Transform": {
+        "posX": 17.07407,
+        "posY": 0.982061744,
+        "posZ": 0.511031866,
+        "rotX": -4.542765E-06,
+        "rotY": 90.02085,
+        "rotZ": -1.41595569E-06,
+        "scaleX": 0.375000447,
+        "scaleY": 0.375000447,
+        "scaleZ": 0.375000447
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 0.7867647,
+        "g": 0.7867647,
+        "b": 0.7867647
+      },
+      "Tags": [
+        "Purple"
+      ],
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "CustomImage": {
+        "ImageURL": "http://cloud-3.steamusercontent.com/ugc/2057633340020313087/952D9E0B153AE35473DA1E5E4485C19CC13A7F9B/",
+        "ImageSecondaryURL": "",
+        "ImageScalar": 1.0,
+        "WidthScale": 1.44722223
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": "",
+      "AttachedSnapPoints": [
+        {
+          "Position": {
+            "x": -1.70487273,
+            "y": 0.5922457,
+            "z": 4.65217447
+          },
+          "Rotation": {
+            "x": -6.99083444E-07,
+            "y": 359.978882,
+            "z": 180.0
+          }
+        },
+        {
+          "Position": {
+            "x": 6.421097,
+            "y": 0.5922457,
+            "z": 4.73291874
+          },
+          "Rotation": {
+            "x": 1.98304019E-06,
+            "y": 359.978638,
+            "z": 180.0
+          }
+        },
+        {
+          "Position": {
+            "x": 2.427551,
+            "y": 0.592245936,
+            "z": 4.69387674
+          },
+          "Rotation": {
+            "x": 1.28217052E-05,
+            "y": 359.947662,
+            "z": -1.25307025E-07
+          }
+        },
+        {
+          "Position": {
+            "x": -6.498179,
+            "y": 0.5922418,
+            "z": 4.631107
+          },
+          "Rotation": {
+            "x": 6.41762426E-06,
+            "y": 359.9787,
+            "z": 4.43342827E-07
+          }
+        },
+        {
+          "Position": {
+            "x": -6.482119,
+            "y": 0.5922434,
+            "z": -4.484806
+          },
+          "Rotation": {
+            "x": 7.945485E-06,
+            "y": 359.9787,
+            "z": -1.21888519E-07
+          }
+        },
+        {
+          "Position": {
+            "x": -1.75949085,
+            "y": 0.592245162,
+            "z": -4.44758368
+          },
+          "Rotation": {
+            "x": 3.21791845E-06,
+            "y": 359.979279,
+            "z": 180.0
+          }
+        }
+      ]
+    },
+    {
+      "GUID": "2ef9b7",
+      "Name": "Custom_Board",
+      "Transform": {
+        "posX": -16.999176,
+        "posY": 0.982063,
+        "posZ": 0.318844736,
+        "rotX": -9.692084E-06,
+        "rotY": 270.0193,
+        "rotZ": 9.045617E-06,
+        "scaleX": 0.375000447,
+        "scaleY": 0.375000447,
+        "scaleZ": 0.375000447
+      },
+      "Nickname": "",
+      "Description": "",
+      "GMNotes": "",
+      "AltLookAngle": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "ColorDiffuse": {
+        "r": 0.7867647,
+        "g": 0.7867647,
+        "b": 0.7867647
+      },
+      "Tags": [
+        "Yellow"
+      ],
+      "LayoutGroupSortIndex": 0,
+      "Value": 0,
+      "Locked": true,
+      "Grid": true,
+      "Snap": true,
+      "IgnoreFoW": false,
+      "MeasureMovement": false,
+      "DragSelectable": true,
+      "Autoraise": true,
+      "Sticky": true,
+      "Tooltip": true,
+      "GridProjection": false,
+      "HideWhenFaceDown": false,
+      "Hands": false,
+      "CustomImage": {
+        "ImageURL": "http://cloud-3.steamusercontent.com/ugc/2057633340020313087/952D9E0B153AE35473DA1E5E4485C19CC13A7F9B/",
+        "ImageSecondaryURL": "",
+        "ImageScalar": 1.0,
+        "WidthScale": 1.44722223
+      },
+      "LuaScript": "",
+      "LuaScriptState": "",
+      "XmlUI": "",
+      "AttachedSnapPoints": [
+        {
+          "Position": {
+            "x": -1.70487273,
+            "y": 0.5922457,
+            "z": 4.65217447
+          },
+          "Rotation": {
+            "x": -6.990835E-07,
+            "y": 359.978882,
+            "z": 180.0
+          }
+        },
+        {
+          "Position": {
+            "x": 6.421097,
+            "y": 0.5922457,
+            "z": 4.73291874
+          },
+          "Rotation": {
+            "x": 1.98304019E-06,
+            "y": 359.978638,
+            "z": 180.0
+          }
+        },
+        {
+          "Position": {
+            "x": 2.427551,
+            "y": 0.592245936,
+            "z": 4.69387674
+          },
+          "Rotation": {
+            "x": 1.28217062E-05,
+            "y": 359.947662,
+            "z": -1.25307025E-07
+          }
+        },
+        {
+          "Position": {
+            "x": -6.498179,
+            "y": 0.5922418,
+            "z": 4.631107
+          },
+          "Rotation": {
+            "x": 6.41762472E-06,
+            "y": 359.9787,
+            "z": 4.43342827E-07
+          }
+        },
+        {
+          "Position": {
+            "x": -6.482119,
+            "y": 0.5922434,
+            "z": -4.484806
+          },
+          "Rotation": {
+            "x": 7.945485E-06,
+            "y": 359.9787,
+            "z": -1.21888519E-07
+          }
+        },
+        {
+          "Position": {
+            "x": -1.75949085,
+            "y": 0.592245162,
+            "z": -4.44758368
+          },
+          "Rotation": {
+            "x": 3.21791845E-06,
+            "y": 359.979279,
+            "z": 180.0
+          }
+        }
+      ]
+    },
+    {
       "GUID": "bceb10",
       "Name": "HandTrigger",
       "Transform": {
@@ -1239,7 +3111,7 @@
         "r": 0.856,
         "g": 0.09999997,
         "b": 0.09399996,
-        "a": 0.0
+        "a": 0.5
       },
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -1286,7 +3158,7 @@
         "r": 0.905,
         "g": 0.898,
         "b": 0.171999961,
-        "a": 0.0
+        "a": 0.5
       },
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -1333,7 +3205,7 @@
         "r": 0.627,
         "g": 0.124999978,
         "b": 0.941,
-        "a": 0.0
+        "a": 0.5
       },
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -1380,7 +3252,7 @@
         "r": 0.117999978,
         "g": 0.53,
         "b": 1.0,
-        "a": 0.0
+        "a": 0.5
       },
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -1427,7 +3299,7 @@
         "r": 1.0,
         "g": 1.0,
         "b": 1.0,
-        "a": 0.0
+        "a": 0.5
       },
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -1474,7 +3346,7 @@
         "r": 0.191999972,
         "g": 0.701,
         "b": 0.167999953,
-        "a": 0.0
+        "a": 0.5
       },
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -1521,7 +3393,7 @@
         "r": 0.96,
         "g": 0.438999981,
         "b": 0.807,
-        "a": 0.0
+        "a": 0.5
       },
       "LayoutGroupSortIndex": 0,
       "Value": 0,
@@ -1546,11 +3418,11 @@
       "GUID": "4a8259",
       "Name": "Deck",
       "Transform": {
-        "posX": -0.5700784,
+        "posX": -0.570078552,
         "posY": 1.3997519,
-        "posZ": 5.50006962,
-        "rotX": -6.16076647E-08,
-        "rotY": 179.9929,
+        "posZ": 5.50007,
+        "rotX": 1.15197466E-07,
+        "rotY": 179.992874,
         "rotZ": 180.0,
         "scaleX": 1.0,
         "scaleY": 1.0,
@@ -1701,12 +3573,12 @@
           "GUID": "5650fc",
           "Name": "Card",
           "Transform": {
-            "posX": -4.439984,
-            "posY": 0.9736315,
-            "posZ": 5.49997425,
-            "rotX": -0.00022354156,
-            "rotY": 179.996689,
-            "rotZ": 0.00171704532,
+            "posX": -0.570073,
+            "posY": 1.84705091,
+            "posZ": 5.500067,
+            "rotX": 0.00056510634,
+            "rotY": 180.0,
+            "rotZ": 180.000534,
             "scaleX": 1.0,
             "scaleY": 1.0,
             "scaleZ": 1.0
@@ -6749,11 +8621,11 @@
       "GUID": "c1f576",
       "Name": "3DText",
       "Transform": {
-        "posX": -0.5664617,
-        "posY": 0.961093247,
-        "posZ": 2.99991536,
+        "posX": -0.566461861,
+        "posY": 0.961091638,
+        "posZ": 2.99990773,
         "rotX": 90.0,
-        "rotY": -2.44690336E-12,
+        "rotY": -2.30296728E-12,
         "rotZ": 0.0,
         "scaleX": 1.0,
         "scaleY": 1.0,
@@ -6803,11 +8675,11 @@
       "GUID": "56e6a1",
       "Name": "3DText",
       "Transform": {
-        "posX": 3.43597031,
-        "posY": 0.9610919,
-        "posZ": 2.999916,
+        "posX": 3.4359777,
+        "posY": 0.9610904,
+        "posZ": 2.99991035,
         "rotX": 90.0,
-        "rotY": -2.44690336E-12,
+        "rotY": -2.30296728E-12,
         "rotZ": 0.0,
         "scaleX": 1.0,
         "scaleY": 1.0,
@@ -6857,11 +8729,11 @@
       "GUID": "0eb9eb",
       "Name": "3DText",
       "Transform": {
-        "posX": -4.44297647,
-        "posY": 0.961093664,
-        "posZ": 3.05014253,
+        "posX": -4.44298363,
+        "posY": 0.961092,
+        "posZ": 3.0501368,
         "rotX": 90.0,
-        "rotY": -2.44690336E-12,
+        "rotY": -2.30296728E-12,
         "rotZ": 0.0,
         "scaleX": 1.0,
         "scaleY": 1.0,
@@ -6914,7 +8786,7 @@
         "posX": -0.513273954,
         "posY": 1.16000032,
         "posZ": 13.6253138,
-        "rotX": -9.83817046E-08,
+        "rotX": 1.77868131E-07,
         "rotY": 180.0,
         "rotZ": 180.0,
         "scaleX": 1.0,
@@ -7361,7 +9233,7 @@
         "posX": -4.439999,
         "posY": 1.01944292,
         "posZ": 5.49999952,
-        "rotX": -4.26023128E-08,
+        "rotX": -9.489035E-08,
         "rotY": 180.0,
         "rotZ": 180.0,
         "scaleX": 1.0,
@@ -7944,7 +9816,7 @@
         "rotY": 0.0,
         "rotZ": 0.0,
         "scaleX": 2.47509956,
-        "scaleY": 0.5,
+        "scaleY": 4.5,
         "scaleZ": 3.43183327
       },
       "Nickname": "",
@@ -7959,7 +9831,7 @@
         "r": 0.856,
         "g": 0.09999997,
         "b": 0.09399996,
-        "a": 0.75
+        "a": 0.0
       },
       "Tags": [
         "Red"
@@ -7997,7 +9869,7 @@
         "rotY": 0.0,
         "rotZ": 0.0,
         "scaleX": 2.48,
-        "scaleY": 0.5,
+        "scaleY": 4.5,
         "scaleZ": 3.43
       },
       "Nickname": "",
@@ -8012,7 +9884,7 @@
         "r": 1.0,
         "g": 1.0,
         "b": 1.0,
-        "a": 0.25
+        "a": 0.0
       },
       "Tags": [
         "White"
@@ -8050,7 +9922,7 @@
         "rotY": 0.0,
         "rotZ": 0.0,
         "scaleX": 2.48,
-        "scaleY": 0.5,
+        "scaleY": 4.5,
         "scaleZ": 3.43
       },
       "Nickname": "",
@@ -8065,7 +9937,7 @@
         "r": 0.96,
         "g": 0.438999981,
         "b": 0.807,
-        "a": 0.75
+        "a": 0.0
       },
       "Tags": [
         "Pink"
@@ -8103,7 +9975,7 @@
         "rotY": 0.0,
         "rotZ": 0.0,
         "scaleX": 3.43,
-        "scaleY": 0.5,
+        "scaleY": 4.5,
         "scaleZ": 2.48
       },
       "Nickname": "",
@@ -8118,7 +9990,7 @@
         "r": 0.627,
         "g": 0.124999978,
         "b": 0.941,
-        "a": 0.75
+        "a": 0.0
       },
       "Tags": [
         "Purple"
@@ -8156,7 +10028,7 @@
         "rotY": 0.0,
         "rotZ": 0.0,
         "scaleX": 2.48,
-        "scaleY": 0.5,
+        "scaleY": 4.5,
         "scaleZ": 3.43
       },
       "Nickname": "",
@@ -8171,7 +10043,7 @@
         "r": 0.117999978,
         "g": 0.53,
         "b": 1.0,
-        "a": 0.75
+        "a": 0.0
       },
       "Tags": [
         "Blue"
@@ -8209,7 +10081,7 @@
         "rotY": 0.0,
         "rotZ": 0.0,
         "scaleX": 2.48,
-        "scaleY": 0.5,
+        "scaleY": 4.5,
         "scaleZ": 3.43
       },
       "Nickname": "",
@@ -8224,7 +10096,7 @@
         "r": 0.191999972,
         "g": 0.701,
         "b": 0.167999953,
-        "a": 0.75
+        "a": 0.0
       },
       "Tags": [
         "Green"
@@ -8262,7 +10134,7 @@
         "rotY": 0.0,
         "rotZ": 0.0,
         "scaleX": 3.43,
-        "scaleY": 0.5,
+        "scaleY": 4.5,
         "scaleZ": 2.48
       },
       "Nickname": "",
@@ -8277,7 +10149,7 @@
         "r": 0.905,
         "g": 0.898,
         "b": 0.171999961,
-        "a": 0.75
+        "a": 0.0
       },
       "Tags": [
         "Yellow"
@@ -8666,9 +10538,9 @@
       "Name": "Deck",
       "Transform": {
         "posX": 3.44,
-        "posY": 1.1012814,
+        "posY": 1.10128152,
         "posZ": 5.5,
-        "rotX": -6.185221E-08,
+        "rotX": 6.614754E-08,
         "rotY": 180.0,
         "rotZ": 180.0,
         "scaleX": 1.0,
@@ -10283,7 +12155,7 @@
         "posY": 1.02,
         "posZ": 5.5,
         "rotX": 0.0,
-        "rotY": 0.8329995,
+        "rotY": 0.8329999,
         "rotZ": 0.0,
         "scaleX": 1.0,
         "scaleY": 5.1,


### PR DESCRIPTION
### Feature Overview
increase hidden zone height (y-axis), avoiding card exposure during flip

![image](https://github.com/wuyee-5115/tts-message-mod/assets/78011809/fc831624-4da1-49a7-9761-d77fcce2ac7a)

### Important Notes

To prevent card exposure, we can consider alternative approaches:
1. Lock the cards and reveal identities to players when hovering over them.
2. Adjust the opacity of the hidden zone for a less conspicuous appearance.

These solutions can be implemented as needed in the future.

### Commits

increase hidden zone height (y-axis), avoding card exposure during flip

wy-13